### PR TITLE
Add SQLAlchemy setup

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,0 +1,20 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+import os
+from dotenv import load_dotenv
+
+load_dotenv()  # loads DATABASE_URL
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./substack.db")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args=(
+        {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+    ),
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ pipenv==2025.0.2
 platformdirs==4.3.8
 setuptools==80.4.0
 virtualenv==20.31.2
+
+SQLAlchemy==2.0.29
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- set up database connection using SQLAlchemy
- include dotenv loader for DB URL
- add SQLAlchemy and python-dotenv to requirements

## Testing
- `python -m py_compile db.py`
- `pip install SQLAlchemy==2.0.29 python-dotenv==1.0.1` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687517cc77ec832a8c8041077f628216