### PR TITLE
Add Alembic migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = env:DATABASE_URL
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+propagate = 0
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,54 @@
+from logging.config import fileConfig
+import os
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+from db import Base  # noqa
+
+target_metadata = Base.metadata
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_create_posts_table.py
+++ b/alembic/versions/0001_create_posts_table.py
@@ -1,0 +1,28 @@
+"""create posts table
+
+Revision ID: 0001_create_posts
+Revises: 
+Create Date: 2025-07-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001_create_posts'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'posts',
+        sa.Column('id', sa.Text(), primary_key=True),
+        sa.Column('title', sa.Text()),
+        sa.Column('link', sa.Text()),
+        sa.Column('summary', sa.Text()),
+        sa.Column('published', sa.Text()),
+    )
+
+def downgrade() -> None:
+    op.drop_table('posts')

--- a/feeds/ingestion.py
+++ b/feeds/ingestion.py
@@ -1,5 +1,8 @@
 import sqlite3
 import feedparser
+from alembic.config import Config
+from alembic import command
+import os
 
 # Configuration
 FEED_URL = 'https://geoffreyducharme.substack.com/feed'
@@ -7,22 +10,9 @@ DB_PATH = '../substack.db'
 
 
 def init_db(db_path=DB_PATH):
-    """
-    Initialize the SQLite database and create the posts table if it doesn't exist.
-    """
-    conn = sqlite3.connect(db_path)
-    c = conn.cursor()
-    c.execute('''
-        CREATE TABLE IF NOT EXISTS posts (
-            id TEXT PRIMARY KEY,
-            title TEXT,
-            link TEXT,
-            summary TEXT,
-            published TEXT
-        )
-    ''')
-    conn.commit()
-    conn.close()
+    """Run database migrations to ensure the schema exists."""
+    alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "..", "alembic.ini"))
+    command.upgrade(alembic_cfg, "head")
 
 
 def fetch_feed(feed_url=FEED_URL):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ virtualenv==20.31.2
 
 SQLAlchemy==2.0.29
 python-dotenv==1.0.1
+alembic==1.13.1


### PR DESCRIPTION
## Summary
- install Alembic
- set up migration environment
- create first migration for posts table
- run migrations during ingest init

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement certifi==2025.4.26)*

------
https://chatgpt.com/codex/tasks/task_e_68751995e118832abd61ebd4b2dd5127