### PR TITLE
Load env DATABASE_URL for Alembic

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -10,6 +10,15 @@ from alembic import context
 # access to the values within the .ini file in use.
 config = context.config
 
+# Load environment variables from a .env file if present
+from dotenv import load_dotenv
+load_dotenv()
+
+# If a DATABASE_URL is provided at runtime, override the value from alembic.ini
+database_url = os.getenv("DATABASE_URL")
+if database_url:
+    config.set_main_option("sqlalchemy.url", database_url)
+
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:


### PR DESCRIPTION
## Summary
- use python-dotenv inside `alembic/env.py`
- override `sqlalchemy.url` if `DATABASE_URL` is supplied

## Testing
- `python -m compileall -q alembic/env.py src/auto`

------
https://chatgpt.com/codex/tasks/task_e_6875218def54832aa20214981ff268fb