### PR TITLE
Add uvicorn server invoke task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -10,3 +10,14 @@ def ingest(ctx, host="localhost", port=8000):
     url = f"http://{host}:{port}/ingest"
     ctx.run(f"curl -s -X POST {url}", echo=True)
 
+
+@task
+def uv(ctx, host="127.0.0.1", port=8000, reload=True):
+    """Start the FastAPI server using uvicorn."""
+    reload_flag = "--reload" if reload else ""
+    ctx.run(
+        f"uvicorn auto.main:app {reload_flag} --host {host} --port {port}",
+        pty=True,
+        echo=True,
+    )
+


### PR DESCRIPTION
## Summary
- make an Invoke task called `uv` that runs the FastAPI app with uvicorn

## Testing
- `invoke -l`
- `python -m compileall -q src tasks.py`
- `invoke -R uv --host 0.0.0.0 --port 8000 --no-reload`

------
https://chatgpt.com/codex/tasks/task_e_6875246318f0832aa9e61fad11371d85