### PR TITLE
Fix FastAPI entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from auto.main import app
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- expose `auto.main` as `main` so `uvicorn main:app` works

## Testing
- `python -m py_compile main.py src/auto/*.py src/auto/feeds/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687524b916bc832a969f47b75750d48b