### PR TITLE
Fix Alembic config path

### DIFF
--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -11,7 +11,9 @@ DB_PATH = '../../substack.db'
 
 def init_db(db_path=DB_PATH):
     """Run database migrations to ensure the schema exists."""
-    alembic_cfg = Config(os.path.join(os.path.dirname(__file__), '..', '..', 'alembic.ini'))
+    here = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    ini_path = os.path.join(here, "alembic.ini")
+    alembic_cfg = Config(ini_path)
     command.upgrade(alembic_cfg, "head")
 
 


### PR DESCRIPTION
## Summary
- correct path to `alembic.ini` in `init_db`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687529d7b6b8832aa9710838392f9ca4