### PR TITLE
Fix Alembic startup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Auto
+
+This project uses FastAPI with Alembic for database migrations.
+
+## Running the server
+
+Install dependencies and start the development server from the project root:
+
+```bash
+pip install -r requirements.txt
+invoke uv
+```
+
+Running from the project root ensures Alembic can locate `alembic.ini` and migrations.

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -2,18 +2,20 @@ import sqlite3
 import feedparser
 from alembic.config import Config
 from alembic import command
-import os
+from pathlib import Path
 
 # Configuration
 FEED_URL = 'https://geoffreyducharme.substack.com/feed'
-DB_PATH = '../../substack.db'
+
+# Determine project root four directories above this file
+BASE_DIR = Path(__file__).resolve().parents[3]
+DB_PATH = str(BASE_DIR / 'substack.db')
+ALEMBIC_INI = BASE_DIR / 'alembic.ini'
 
 
 def init_db(db_path=DB_PATH):
     """Run database migrations to ensure the schema exists."""
-    here = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-    ini_path = os.path.join(here, "alembic.ini")
-    alembic_cfg = Config(ini_path)
+    alembic_cfg = Config(str(ALEMBIC_INI))
     command.upgrade(alembic_cfg, "head")
 
 


### PR DESCRIPTION
## Summary
- fix incorrect Alembic path resolution in `init_db`
- document how to run the server from project root

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement SQLAlchemy-2.0.41)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752b1a2a7c832aada3e6eed0042704