### PR TITLE
Add pytest optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ dependencies = [
   "python-dotenv",
 ]
 
+[project.optional-dependencies]
+dev = [
+  "pytest",
+]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add pytest under the optional dev dependencies in `pyproject.toml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752ca83ef0832aa7a97a8ce6e97c75