### PR TITLE
Add Mastodon posting utility

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,2 @@
-MASTODON_INSTANCE = os.getenv("MASTODON_INSTANCE", "https://mastodon.social")
-ACCESS_TOKEN       = os.getenv("MASTODON_TOKEN")  # copy from your dev settings
+MASTODON_INSTANCE=https://mastodon.social
+MASTODON_TOKEN=YOUR_ACCESS_TOKEN_HERE

--- a/src/auto/mastodon_client.py
+++ b/src/auto/mastodon_client.py
@@ -1,0 +1,22 @@
+from mastodon import Mastodon
+from dotenv import load_dotenv
+from pathlib import Path
+import os
+
+# Load environment variables from the project root .env file
+BASE_DIR = Path(__file__).resolve().parents[2]
+load_dotenv(BASE_DIR / ".env")
+
+MASTODON_INSTANCE = os.getenv("MASTODON_INSTANCE", "https://mastodon.social")
+ACCESS_TOKEN = os.getenv("MASTODON_TOKEN")
+
+
+def post_to_mastodon(status: str, visibility: str = "private"):
+    """Post a status to Mastodon."""
+    masto = Mastodon(access_token=ACCESS_TOKEN, api_base_url=MASTODON_INSTANCE)
+    masto.toot(status, visibility=visibility)
+    print("Posted to Mastodon!")
+
+
+if __name__ == "__main__":
+    post_to_mastodon("Hello world! My Substack → Socials bot is live 🚀")


### PR DESCRIPTION
## Summary
- implement `post_to_mastodon` utility using `python-dotenv`
- sample `.env` file for Mastodon credentials

## Testing
- `python -m py_compile src/auto/mastodon_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6875440a7d28832a877931a05fa7e150