### PR TITLE
Support custom db path in init_db

### DIFF
--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -16,6 +16,12 @@ ALEMBIC_INI = BASE_DIR / 'alembic.ini'
 def init_db(db_path=DB_PATH):
     """Run database migrations to ensure the schema exists."""
     alembic_cfg = Config(str(ALEMBIC_INI))
+    if db_path != DB_PATH:
+        # If using a custom path, override the database URL
+        url = db_path
+        if not db_path.startswith("sqlite"):
+            url = f"sqlite:///{db_path}"
+        alembic_cfg.set_main_option("sqlalchemy.url", url)
     command.upgrade(alembic_cfg, "head")
 
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,44 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from auto.feeds.ingestion import init_db, save_entries
+
+class DummyEntry:
+    def __init__(self, id, title, link, summary="", published=""):
+        self.id = id
+        self.title = title
+        self.link = link
+        self.summary = summary
+        self.published = published
+
+class DummyFeed:
+    def __init__(self, entries):
+        self.entries = entries
+
+
+def test_save_entries_inserts_and_ignores_duplicates(tmp_path):
+    db_path = tmp_path / "test.db"
+    init_db(str(db_path))
+
+    feed = DummyFeed([
+        DummyEntry("1", "First", "http://example.com/1"),
+        DummyEntry("2", "Second", "http://example.com/2"),
+    ])
+
+    # First insertion
+    save_entries(feed, str(db_path))
+    # Duplicate run should not insert additional rows
+    save_entries(feed, str(db_path))
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.execute("SELECT id, title FROM posts ORDER BY id")
+    rows = cur.fetchall()
+    conn.close()
+
+    assert rows == [
+        ("1", "First"),
+        ("2", "Second"),
+    ]


### PR DESCRIPTION
## Summary
- allow overriding the database URL when running migrations
- add an ingestion test using a temp database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876406c2f0c832abdc60e1b4317cf48