### PR TITLE
Add feed parsing tests and update parser

### DIFF
--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -43,12 +43,22 @@ def _parse_entry(item):
     The helper works with BeautifulSoup/feedparser elements as well as the
     simple dummy objects used in unit tests.
     """
-    if hasattr(item, "findtext"):
+    if callable(getattr(item, "findtext", None)):
         guid = item.findtext("guid") or item.findtext("id") or item.findtext("link")
         title = item.findtext("title", "")
         link = item.findtext("link", "")
         summary = item.findtext("description", "")
         published = item.findtext("pubDate", "")
+    elif hasattr(item, "find"):
+        def _text(tag_name, default=""):
+            el = item.find(tag_name)
+            return el.get_text() if el else default
+
+        guid = _text("guid") or _text("id") or _text("link")
+        title = _text("title")
+        link = _text("link")
+        summary = _text("description")
+        published = _text("pubDate")
     else:
         guid = getattr(item, "id", getattr(item, "link", ""))
         title = getattr(item, "title", "")

--- a/tests/test_feed_parsing.py
+++ b/tests/test_feed_parsing.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from bs4 import BeautifulSoup
+import requests
+from auto.feeds.ingestion import _parse_entry, fetch_feed
+
+
+def test_parse_entry_from_soup():
+    xml = (
+        "<item>"
+        "<guid>123</guid>"
+        "<title>Example</title>"
+        "<link>http://example.com</link>"
+        "<description>Summary</description>"
+        "<pubDate>Mon, 01 Jan 2000 00:00:00 +0000</pubDate>"
+        "</item>"
+    )
+    item = BeautifulSoup(xml, "xml").find("item")
+    result = _parse_entry(item)
+    assert result == (
+        "123",
+        "Example",
+        "http://example.com",
+        "Summary",
+        "Mon, 01 Jan 2000 00:00:00 +0000",
+    )
+
+
+def test_parse_entry_from_dummy_object():
+    dummy = SimpleNamespace(
+        id="1",
+        title="Dummy",
+        link="http://dummy",
+        summary="Body",
+        published="2025-01-01",
+    )
+    result = _parse_entry(dummy)
+    assert result == ("1", "Dummy", "http://dummy", "Body", "2025-01-01")
+
+
+def test_fetch_feed_returns_items(monkeypatch):
+    sample_xml = Path(__file__).with_name("sample_feed.xml").read_bytes()
+
+    class DummyResponse:
+        def __init__(self, content):
+            self.content = content
+            self.status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, timeout=10):
+        return DummyResponse(sample_xml)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    items = fetch_feed("http://example.com/feed")
+    assert isinstance(items, list)
+    assert all(item.name == "item" for item in items)
+


### PR DESCRIPTION
## Summary
- expand `_parse_entry` to handle BeautifulSoup tags
- add new `tests/test_feed_parsing.py` covering `_parse_entry` and `fetch_feed`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68764a35e99c832a955af7988edbb387