### PR TITLE
Add lxml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following variables are used:
 
 ## Running the server
 
-Install dependencies and start the development server from the project root:
+Install dependencies (which include **lxml** for XML parsing) and start the development server from the project root:
 
 ```bash
 pip install -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "uvicorn",
   "python-dotenv",
   "beautifulsoup4",
+  "lxml",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ h11==0.16.0
 idna==3.10
 iniconfig==2.1.0
 invoke==2.2.0
+lxml==6.0.0
 Mako==1.3.10
 MarkupSafe==3.0.2
 Mastodon.py==2.0.1


### PR DESCRIPTION
## Summary
- add `lxml` as a runtime dependency
- pin `lxml` in requirements.txt
- note `lxml` installation in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876514cd8c0832a8481d36d117842d9