### PR TITLE
Add FastAPI ingestion integration test

### DIFF
--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -1,0 +1,44 @@
+import sqlite3
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+from bs4 import BeautifulSoup
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import auto.main as main
+from auto.feeds import ingestion
+
+
+def test_ingest_endpoint(tmp_path, monkeypatch):
+    sample_xml = Path(__file__).with_name("sample_feed.xml").read_bytes()
+    parsed = BeautifulSoup(sample_xml, "xml").find_all("item")
+
+    monkeypatch.setattr(ingestion, "fetch_feed", lambda: parsed)
+    monkeypatch.setattr(main, "fetch_feed", lambda: parsed)
+
+    db_path = tmp_path / "test.db"
+
+    orig_init_db = ingestion.init_db
+    orig_save_entries = ingestion.save_entries
+
+    def init_db_patch(path=str(db_path)):
+        return orig_init_db(str(db_path))
+
+    def save_entries_patch(items, path=str(db_path)):
+        return orig_save_entries(items, str(db_path))
+
+    monkeypatch.setattr(ingestion, "init_db", init_db_patch)
+    monkeypatch.setattr(ingestion, "save_entries", save_entries_patch)
+    monkeypatch.setattr(main, "save_entries", save_entries_patch)
+    monkeypatch.setattr(main, "init_db", init_db_patch)
+
+    with TestClient(main.app) as client:
+        resp = client.post("/ingest")
+        assert resp.status_code == 200
+
+    conn = sqlite3.connect(db_path)
+    row_count = conn.execute("SELECT COUNT(*) FROM posts").fetchone()[0]
+    conn.close()
+
+    assert row_count == len(parsed)


### PR DESCRIPTION
## Summary
- create test for `/ingest` endpoint using `TestClient`
- patch `fetch_feed` to read `tests/sample_feed.xml`
- patch database functions so FastAPI uses a temporary sqlite db

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876506c0dfc832ab95385875a056276