### PR TITLE
Fix FastAPI warning

### DIFF
--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -1,5 +1,6 @@
 # main.py
 from fastapi import FastAPI, BackgroundTasks
+from contextlib import asynccontextmanager
 from .feeds.ingestion import init_db, fetch_feed, save_entries
 from dotenv import load_dotenv
 import os
@@ -9,11 +10,12 @@ load_dotenv()
 FEED_URL = os.getenv("SUBSTACK_FEED_URL")
 DB_URL   = os.getenv("DATABASE_URL")
 
-app = FastAPI()
-
-@app.on_event("startup")
-async def startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     init_db()
+    yield
+
+app = FastAPI(lifespan=lifespan)
 
 @app.post("/ingest")
 async def ingest(background_tasks: BackgroundTasks):


### PR DESCRIPTION
## Summary
- update FastAPI startup logic to use the new lifespan API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687653750cac832ab3cb5f0afb20baa8