### PR TITLE
Refactor ingestion to use SQLAlchemy

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 - Add automated tests for API endpoints and ingestion workflow.
 
 ## Medium Priority
-- Refactor database code to use SQLAlchemy models instead of raw `sqlite3` statements.
 - Improve logging and error handling for ingestion and publishing tasks.
 
 ## Low Priority

--- a/src/auto/models.py
+++ b/src/auto/models.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, String, Text, Integer, DateTime, text
+
+from .db import Base
+
+class Post(Base):
+    __tablename__ = 'posts'
+
+    id = Column(String, primary_key=True, nullable=False)
+    title = Column(String, nullable=False)
+    link = Column(String, nullable=False)
+    summary = Column(Text)
+    published = Column(String)
+
+class PostStatus(Base):
+    __tablename__ = 'post_status'
+
+    post_id = Column(String, primary_key=True)
+    network = Column(String, primary_key=True)
+    status = Column(String, nullable=False, server_default='pending')
+    attempts = Column(Integer, nullable=False, server_default='0')
+    last_error = Column(Text)
+    updated_at = Column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP'))


### PR DESCRIPTION
## Summary
- define SQLAlchemy models for `posts` and `post_status`
- update ingestion workflow to insert posts via SQLAlchemy instead of sqlite3
- remove completed task from TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687654a764e4832abc4592487f3070b8