### PR TITLE
Add editorconfig and pre-commit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/psf/black
+    rev: 24.4.0
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ urllib3==2.5.0
 uvicorn==0.35.0
 virtualenv==20.31.2
 wheel==0.45.1
+pre-commit==4.2.0


### PR DESCRIPTION
## Summary
- add .editorconfig with standard newline rules
- configure pre-commit with Black, Flake8, and basic sanity checks
- pin pre-commit in requirements

## Testing
- `pytest -q`
- `pre-commit run --files .editorconfig .pre-commit-config.yaml requirements.txt` *(fails: attempted network access to gitlab.com)*

------
https://chatgpt.com/codex/tasks/task_e_687653f9e044832a88afa5503c224051