### PR TITLE
Implement list-posts invoke task with ORM

### DIFF
--- a/src/auto/models.py
+++ b/src/auto/models.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, String, Text, Integer, DateTime, ForeignKey, text
+
+from .db import Base
+
+class Post(Base):
+    __tablename__ = 'posts'
+
+    id = Column(String, primary_key=True)
+    title = Column(String, nullable=False)
+    link = Column(String, nullable=False)
+    summary = Column(Text)
+    published = Column(String)
+
+class PostStatus(Base):
+    __tablename__ = 'post_status'
+
+    post_id = Column(String, ForeignKey('posts.id'), primary_key=True)
+    network = Column(String, primary_key=True)
+    status = Column(String, nullable=False, server_default='pending')
+    attempts = Column(Integer, nullable=False, server_default='0')
+    last_error = Column(Text)
+    updated_at = Column(DateTime, nullable=False, server_default=text('CURRENT_TIMESTAMP'))
+


### PR DESCRIPTION
## Summary
- introduce Post and PostStatus SQLAlchemy models
- rework `list_posts` invoke task to use the ORM

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68765963b5b0832a926e02fb5c718c45