### PR TITLE
Implement SQLAlchemy models

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO
 
 ## High Priority
-- Refactor database code to use SQLAlchemy models instead of raw `sqlite3` statements.
 
 ## Medium Priority
 - Improve logging and error handling for ingestion and publishing tasks.

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -1,9 +1,14 @@
-import sqlite3
 import requests
 from bs4 import BeautifulSoup
 from alembic.config import Config
 from alembic import command
 from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.exc import IntegrityError
+
+from ..models import Post
 
 # Configuration
 FEED_URL = 'https://geoffreyducharme.substack.com/feed'
@@ -14,11 +19,17 @@ DB_PATH = str(BASE_DIR / 'substack.db')
 ALEMBIC_INI = BASE_DIR / 'alembic.ini'
 
 
+def _session_for_path(db_path: str):
+    """Return a SQLAlchemy session for the given database path."""
+    url = db_path if db_path.startswith("sqlite") or "://" in db_path else f"sqlite:///{db_path}"
+    engine = create_engine(url, connect_args={"check_same_thread": False} if url.startswith("sqlite") else {})
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+
+
 def init_db(db_path=DB_PATH):
     """Run database migrations to ensure the schema exists."""
     alembic_cfg = Config(str(ALEMBIC_INI))
     if db_path != DB_PATH:
-        # If using a custom path, override the database URL
         url = db_path
         if not db_path.startswith("sqlite"):
             url = f"sqlite:///{db_path}"
@@ -27,10 +38,7 @@ def init_db(db_path=DB_PATH):
 
 
 def fetch_feed(feed_url=FEED_URL):
-    """
-    Fetch and parse the RSS feed using BeautifulSoup.
-    Returns a list of parsed <item> elements.
-    """
+    """Fetch and parse the RSS feed using BeautifulSoup."""
     response = requests.get(feed_url, timeout=10)
     response.raise_for_status()
     soup = BeautifulSoup(response.content, "lxml")
@@ -38,11 +46,7 @@ def fetch_feed(feed_url=FEED_URL):
 
 
 def _parse_entry(item):
-    """Return common fields extracted from a feed entry.
-
-    The helper works with BeautifulSoup/feedparser elements as well as the
-    simple dummy objects used in unit tests.
-    """
+    """Return common fields extracted from a feed entry."""
     if callable(getattr(item, "findtext", None)):
         guid = item.findtext("guid") or item.findtext("id") or item.findtext("link")
         title = item.findtext("title", "")
@@ -70,33 +74,23 @@ def _parse_entry(item):
 
 
 def save_entries(items, db_path=DB_PATH):
-    """Save new entries from the feed into the database.
+    """Save new entries from the feed into the database."""
+    session = _session_for_path(db_path)
 
-    The function accepts either an iterable of parsed ``<item>`` elements or a
-    feed object with an ``entries`` attribute.  Tests use a small dummy object so
-    we support both real feedparser/BeautifulSoup objects and simple stubs.
-    """
-    conn = sqlite3.connect(db_path)
-    c = conn.cursor()
-
-    # Allow passing a feed object with an ``entries`` attribute
     items_iter = getattr(items, "entries", items)
 
     for item in items_iter:
         guid, title, link, summary, published = _parse_entry(item)
-
+        post = Post(id=guid, title=title, link=link, summary=summary, published=published)
+        session.add(post)
         try:
-            c.execute(
-                'INSERT INTO posts (id, title, link, summary, published) VALUES (?, ?, ?, ?, ?)',
-                (guid, title, link, summary, published)
-            )
+            session.commit()
             print(f"Saved post: {title}")
-        except sqlite3.IntegrityError:
-            # Duplicate entry, skip
+        except IntegrityError:
+            session.rollback()
             print(f"Skipping existing post: {title}")
 
-    conn.commit()
-    conn.close()
+    session.close()
 
 
 def main():
@@ -107,4 +101,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/src/auto/models.py
+++ b/src/auto/models.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, String, Text, Integer, DateTime, text
+
+from .db import Base
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(String, primary_key=True, nullable=False)
+    title = Column(String, nullable=False)
+    link = Column(String, nullable=False)
+    summary = Column(Text)
+    published = Column(String)
+
+
+class PostStatus(Base):
+    __tablename__ = "post_status"
+
+    post_id = Column(String, primary_key=True, nullable=False)
+    network = Column(String, primary_key=True, nullable=False)
+    status = Column(String, nullable=False, server_default="pending")
+    attempts = Column(Integer, nullable=False, server_default="0")
+    last_error = Column(Text)
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )


### PR DESCRIPTION
## Summary
- refactor ingestion to use SQLAlchemy instead of raw sqlite3
- add SQLAlchemy models for Post and PostStatus
- remove completed task from TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765a6af6c4832a8a81c6408a4d4162