### PR TITLE
Improve logging and error handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## High Priority
 
 ## Medium Priority
-- Improve logging and error handling for ingestion and publishing tasks.
 - Implement periodic/scheduled ingestion instead of manual triggering.
 - Set up CI to run tests and linting automatically.
 

--- a/src/auto/__init__.py
+++ b/src/auto/__init__.py
@@ -1,0 +1,7 @@
+import logging
+import os
+
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -3,9 +3,11 @@ from fastapi import FastAPI, BackgroundTasks
 from contextlib import asynccontextmanager
 from .feeds.ingestion import init_db, fetch_feed, save_entries
 from dotenv import load_dotenv
+import logging
 import os
 
 load_dotenv()
+logger = logging.getLogger(__name__)
 
 FEED_URL = os.getenv("SUBSTACK_FEED_URL")
 DB_URL   = os.getenv("DATABASE_URL")
@@ -19,10 +21,14 @@ app = FastAPI(lifespan=lifespan)
 
 @app.post("/ingest")
 async def ingest(background_tasks: BackgroundTasks):
+    logger.info("Ingestion requested")
     background_tasks.add_task(run_ingest)
     return {"status": "ingestion queued"}
 
 def run_ingest():
-    items = fetch_feed()
-    save_entries(items)
+    try:
+        items = fetch_feed()
+        save_entries(items)
+    except Exception as exc:
+        logger.error("Ingestion failed: %s", exc)
 

--- a/src/auto/socials/mastodon_client.py
+++ b/src/auto/socials/mastodon_client.py
@@ -1,6 +1,7 @@
 from mastodon import Mastodon
 from dotenv import load_dotenv
 from pathlib import Path
+import logging
 import os
 
 # Load environment variables from the project root .env file
@@ -10,15 +11,21 @@ load_dotenv(BASE_DIR / ".env")
 MASTODON_INSTANCE = os.getenv("MASTODON_INSTANCE", "https://mastodon.social")
 ACCESS_TOKEN = os.getenv("MASTODON_TOKEN")
 
+logger = logging.getLogger(__name__)
+
 
 def post_to_mastodon(status: str, visibility: str = "private") -> None:
     """Post a status to Mastodon."""
-    masto = Mastodon(access_token=ACCESS_TOKEN, api_base_url=MASTODON_INSTANCE)
-    # `toot` in Mastodon.py 2.x does not accept extra keyword arguments such as
-    # ``visibility``.  Use ``status_post`` instead, which exposes these
-    # parameters.
-    masto.status_post(status=status, visibility=visibility)
-    print("Posted to Mastodon!")
+    try:
+        masto = Mastodon(access_token=ACCESS_TOKEN, api_base_url=MASTODON_INSTANCE)
+        # `toot` in Mastodon.py 2.x does not accept extra keyword arguments such as
+        # ``visibility``.  Use ``status_post`` instead, which exposes these
+        # parameters.
+        masto.status_post(status=status, visibility=visibility)
+        logger.info("Posted to Mastodon")
+    except Exception as exc:
+        logger.error("Failed to post to Mastodon: %s", exc)
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- configure basic logging in `auto` package
- add logging and better exception handling for feed ingestion
- log ingestion lifecycle in API
- add logging and error handling to Mastodon client
- update TODO list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765fb91a00832a988acb11cb8eda89