### PR TITLE
Fix feed parser to use XML

### DIFF
--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -47,7 +47,8 @@ def fetch_feed(feed_url=FEED_URL):
     """Fetch and parse the RSS feed using BeautifulSoup."""
     response = requests.get(feed_url, timeout=10)
     response.raise_for_status()
-    soup = BeautifulSoup(response.content, "lxml")
+    # Use the XML parser to avoid XMLParsedAsHTMLWarning
+    soup = BeautifulSoup(response.content, features="xml")
     return soup.find_all("item")
 
 


### PR DESCRIPTION
## Summary
- parse the RSS feed using the XML parser to avoid XMLParsedAsHTMLWarning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765f84d96c832a88c3bd36d1728155