### PR TITLE
Refactor ingestion session handling

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -65,19 +65,30 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+    connectable = config.attributes.get("connection")
 
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata
+    if connectable is None:
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section, {}),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
         )
 
-        with context.begin_transaction():
-            context.run_migrations()
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection, target_metadata=target_metadata
+            )
+
+            with context.begin_transaction():
+                context.run_migrations()
+    else:
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection, target_metadata=target_metadata
+            )
+
+            with context.begin_transaction():
+                context.run_migrations()
 
 
 if context.is_offline_mode():

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -23,26 +23,47 @@ DB_PATH = str(BASE_DIR / 'substack.db')
 ALEMBIC_INI = BASE_DIR / 'alembic.ini'
 
 
-def _session_for_path(db_path: str):
-    """Return a SQLAlchemy session for the given database path."""
-    if db_path == DB_PATH:
-        return SessionLocal()
-    url = db_path if db_path.startswith("sqlite") or "://" in db_path else f"sqlite:///{db_path}"
-    engine = create_engine(
-        url,
-        connect_args={"check_same_thread": False} if url.startswith("sqlite") else {},
-    )
-    return sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+def _session_for_path(db_path: str, *, engine=None, session_factory=None):
+    """Return a SQLAlchemy session for the given database path or engine."""
+    if session_factory is not None:
+        return session_factory()
+
+    if engine is None:
+        if db_path == DB_PATH:
+            return SessionLocal()
+
+        url = db_path if db_path.startswith("sqlite") or "://" in db_path else f"sqlite:///{db_path}"
+        engine = create_engine(
+            url,
+            connect_args={"check_same_thread": False} if url.startswith("sqlite") else {},
+        )
+
+    Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    return Session()
 
 
-def init_db(db_path=DB_PATH):
+def init_db(db_path=DB_PATH, *, engine=None, session_factory=None):
     """Run database migrations to ensure the schema exists."""
     alembic_cfg = Config(str(ALEMBIC_INI))
-    if db_path != DB_PATH:
+
+    bind = engine
+    if bind is None and session_factory is not None:
+        if isinstance(session_factory, sessionmaker):
+            bind = session_factory.kw.get("bind")
+        else:
+            try:
+                bind = session_factory().get_bind()
+            finally:
+                pass
+
+    if bind is not None:
+        alembic_cfg.attributes["connection"] = bind
+    elif db_path != DB_PATH:
         url = db_path
         if not db_path.startswith("sqlite"):
             url = f"sqlite:///{db_path}"
         alembic_cfg.set_main_option("sqlalchemy.url", url)
+
     try:
         command.upgrade(alembic_cfg, "head")
     except Exception as exc:
@@ -90,9 +111,9 @@ def _parse_entry(item):
     return guid, title, link, summary, published
 
 
-def save_entries(items, db_path=DB_PATH):
+def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
     """Save new entries from the feed into the database."""
-    session = _session_for_path(db_path)
+    session = _session_for_path(db_path, engine=engine, session_factory=session_factory)
 
     items_iter = getattr(items, "entries", items)
 

--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import auto.main as main
+from sqlalchemy import create_engine
 from auto.feeds import ingestion
 
 
@@ -18,15 +19,16 @@ def test_ingest_endpoint(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "fetch_feed", lambda: parsed)
 
     db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
 
     orig_init_db = ingestion.init_db
     orig_save_entries = ingestion.save_entries
 
     def init_db_patch(path=str(db_path)):
-        return orig_init_db(str(db_path))
+        return orig_init_db(str(db_path), engine=engine)
 
     def save_entries_patch(items, path=str(db_path)):
-        return orig_save_entries(items, str(db_path))
+        return orig_save_entries(items, str(db_path), engine=engine)
 
     monkeypatch.setattr(ingestion, "init_db", init_db_patch)
     monkeypatch.setattr(ingestion, "save_entries", save_entries_patch)


### PR DESCRIPTION
## Summary
- allow `_session_for_path` to accept injected engine or session factory
- migrate using the provided engine when running `init_db`
- update Alembic environment to support engine injection
- adapt ingestion tests to inject a single engine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68766d7e33a8832a90270dba324c9d8d