### PR TITLE
Add scheduled posting system

### DIFF
--- a/alembic/versions/955b42e04385_add_scheduled_at_column.py
+++ b/alembic/versions/955b42e04385_add_scheduled_at_column.py
@@ -1,0 +1,22 @@
+"""add scheduled_at column
+
+Revision ID: 955b42e04385
+Revises: 468d8314d708
+Create Date: 2025-07-14 17:49:36
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '955b42e04385'
+down_revision: Union[str, Sequence[str], None] = '468d8314d708'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade():
+    op.add_column('post_status', sa.Column('scheduled_at', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')))
+
+
+def downgrade():
+    op.drop_column('post_status', 'scheduled_at')

--- a/src/auto/models.py
+++ b/src/auto/models.py
@@ -16,6 +16,11 @@ class PostStatus(Base):
 
     post_id = Column(String, ForeignKey("posts.id"), primary_key=True)
     network = Column(String, primary_key=True)
+    scheduled_at = Column(
+        DateTime,
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
     status = Column(String, nullable=False, server_default="pending")
     attempts = Column(Integer, nullable=False, server_default="0")
     last_error = Column(Text)

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -1,0 +1,61 @@
+import asyncio
+import logging
+import os
+from datetime import datetime
+from .db import SessionLocal
+from .models import PostStatus, Post
+from .socials.mastodon_client import post_to_mastodon
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL = int(os.getenv("SCHEDULER_POLL_INTERVAL", "5"))
+POST_DELAY = float(os.getenv("POST_DELAY", "1"))
+
+async def _publish(status: PostStatus, session):
+    post = session.get(Post, status.post_id)
+    if not post:
+        logger.error("Post %s not found", status.post_id)
+        status.status = "error"
+        status.last_error = "post not found"
+        status.attempts += 1
+        session.commit()
+        return
+    try:
+        if status.network == "mastodon":
+            await asyncio.to_thread(post_to_mastodon, f"{post.title} {post.link}")
+        else:
+            raise ValueError(f"Unsupported network {status.network}")
+        status.status = "published"
+        status.last_error = None
+    except Exception as exc:
+        status.status = "error"
+        status.last_error = str(exc)
+        logger.error("Failed to publish %s: %s", status.post_id, exc)
+    finally:
+        status.attempts += 1
+        session.commit()
+        await asyncio.sleep(POST_DELAY)
+
+async def process_pending():
+    now = datetime.utcnow()
+    with SessionLocal() as session:
+        statuses = (
+            session.query(PostStatus)
+            .filter(PostStatus.status == "pending", PostStatus.scheduled_at <= now)
+            .order_by(PostStatus.scheduled_at)
+            .all()
+        )
+        for status in statuses:
+            await _publish(status, session)
+
+async def run_scheduler():
+    while True:
+        await process_pending()
+        await asyncio.sleep(POLL_INTERVAL)
+
+
+def main():
+    asyncio.run(run_scheduler())
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,44 @@
+import asyncio
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from sqlalchemy import create_engine
+from auto.feeds.ingestion import init_db
+from auto.db import SessionLocal
+from auto.models import Post, PostStatus
+from auto.scheduler import process_pending
+
+class DummyPoster:
+    called = False
+
+    @classmethod
+    def post(cls, text):
+        cls.called = True
+
+
+def test_process_pending_publishes(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    init_db(str(db_path), engine=engine)
+
+    session_factory = SessionLocal
+    # override SessionLocal to use this engine
+    session_factory.configure(bind=engine)
+
+    with session_factory() as session:
+        post = Post(id="1", title="Title", link="http://example", summary="", published="")
+        session.add(post)
+        status = PostStatus(post_id="1", network="mastodon", scheduled_at=datetime.utcnow() - timedelta(seconds=1))
+        session.add(status)
+        session.commit()
+
+    monkeypatch.setattr("auto.scheduler.post_to_mastodon", lambda text: DummyPoster.post(text))
+
+    asyncio.run(process_pending())
+
+    with session_factory() as session:
+        ps = session.get(PostStatus, {"post_id": "1", "network": "mastodon"})
+        assert ps.status == "published"
+    assert DummyPoster.called


### PR DESCRIPTION
## Summary
- add `scheduled_at` column via Alembic
- implement async scheduler to publish due posts
- expose `invoke schedule` CLI helper
- support scheduling in SQLAlchemy models
- test scheduler behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876706fa3c8832a8f3ed09b92327d02