### PR TITLE
Add post scheduling loop and improved CLI

### DIFF
--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -72,7 +72,7 @@ def init_db(db_path=DB_PATH, *, engine=None, session_factory=None):
 
     try:
         # Use "heads" so multiple migration branches are applied
-        command.upgrade(alembic_cfg, "heads")
+        command.upgrade(alembic_cfg, "head")
     except Exception as exc:
         logger.error("Database initialization failed: %s", exc)
         raise

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -71,7 +71,8 @@ def init_db(db_path=DB_PATH, *, engine=None, session_factory=None):
         alembic_cfg.set_main_option("sqlalchemy.url", url)
 
     try:
-        command.upgrade(alembic_cfg, "head")
+        # Use "heads" so multiple migration branches are applied
+        command.upgrade(alembic_cfg, "heads")
     except Exception as exc:
         logger.error("Database initialization failed: %s", exc)
         raise

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -2,6 +2,7 @@
 from fastapi import FastAPI, BackgroundTasks
 from contextlib import asynccontextmanager
 from .feeds.ingestion import init_db, fetch_feed, save_entries
+from . import scheduler
 from dotenv import load_dotenv
 import logging
 import os
@@ -15,7 +16,11 @@ DB_URL   = os.getenv("DATABASE_URL")
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     init_db()
-    yield
+    await scheduler.start()
+    try:
+        yield
+    finally:
+        await scheduler.stop()
 
 app = FastAPI(lifespan=lifespan)
 


### PR DESCRIPTION
## Summary
- upgrade DB init to handle multiple migration heads
- run the posting scheduler in the FastAPI lifespan
- expose start/stop helpers for the scheduler
- expand `invoke schedule` to accept relative times and multiple networks

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876772501a4832a9f13ab0ae3b0baf2