### PR TITLE
Use env feed URL in ingestion

### DIFF
--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -71,7 +71,7 @@ def init_db(db_path=DB_PATH, *, engine=None, session_factory=None):
         alembic_cfg.set_main_option("sqlalchemy.url", url)
 
     try:
-        command.upgrade(alembic_cfg, "head")
+        command.upgrade(alembic_cfg, "heads")
     except Exception as exc:
         logger.error("Database initialization failed: %s", exc)
         raise

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -27,7 +27,7 @@ async def ingest(background_tasks: BackgroundTasks):
 
 def run_ingest():
     try:
-        items = fetch_feed()
+        items = fetch_feed(FEED_URL)
         save_entries(items)
     except Exception as exc:
         logger.error("Ingestion failed: %s", exc)

--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -15,8 +15,8 @@ def test_ingest_endpoint(tmp_path, monkeypatch):
     sample_xml = Path(__file__).with_name("sample_feed.xml").read_bytes()
     parsed = BeautifulSoup(sample_xml, "xml").find_all("item")
 
-    monkeypatch.setattr(ingestion, "fetch_feed", lambda: parsed)
-    monkeypatch.setattr(main, "fetch_feed", lambda: parsed)
+    monkeypatch.setattr(ingestion, "fetch_feed", lambda url=None: parsed)
+    monkeypatch.setattr(main, "fetch_feed", lambda url=None: parsed)
 
     db_path = tmp_path / "test.db"
     engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
@@ -47,3 +47,24 @@ def test_ingest_endpoint(tmp_path, monkeypatch):
 
     assert len(rows) == len(parsed)
     assert all(r[0] is not None for r in rows)
+
+
+def test_run_ingest_uses_env_variable(monkeypatch):
+    """run_ingest() should pass SUBSTACK_FEED_URL to fetch_feed."""
+    monkeypatch.setenv("SUBSTACK_FEED_URL", "http://env.example/feed")
+
+    import importlib
+    import auto.main as main_module
+    importlib.reload(main_module)
+
+    called = {}
+
+    def fake_fetch(url):
+        called["url"] = url
+        return []
+
+    monkeypatch.setattr(main_module, "fetch_feed", fake_fetch)
+    monkeypatch.setattr(main_module, "save_entries", lambda items: None)
+
+    main_module.run_ingest()
+    assert called.get("url") == "http://env.example/feed"


### PR DESCRIPTION
## Summary
- pass `FEED_URL` from `SUBSTACK_FEED_URL` into `fetch_feed`
- allow injecting feed url in API tests
- check that `run_ingest` uses the environment variable
- fix Alembic migrations when multiple heads exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687675f4a030832a9f677dab450615dc