### PR TITLE
Batch commit in save_entries

### DIFF
--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -71,7 +71,7 @@ def init_db(db_path=DB_PATH, *, engine=None, session_factory=None):
         alembic_cfg.set_main_option("sqlalchemy.url", url)
 
     try:
-        command.upgrade(alembic_cfg, "head")
+        command.upgrade(alembic_cfg, "heads")
     except Exception as exc:
         logger.error("Database initialization failed: %s", exc)
         raise
@@ -90,7 +90,7 @@ def fetch_feed(feed_url=FEED_URL):
 
 
 def _parse_entry(item):
-    """Return common fields extracted from a feed entry."""
+    """Return parsed fields extracted from a feed entry."""
     if callable(getattr(item, "findtext", None)):
         guid = item.findtext("guid") or item.findtext("id") or item.findtext("link")
         title = item.findtext("title", "")
@@ -117,7 +117,20 @@ def _parse_entry(item):
         published = getattr(item, "published", "")
         updated = getattr(item, "updated", getattr(item, "updated_at", ""))
 
-    return guid, title, link, summary, published, updated
+    created_dt = None
+    updated_dt = None
+    if published:
+        try:
+            created_dt = parser.parse(published)
+        except Exception:
+            pass
+    if updated:
+        try:
+            updated_dt = parser.parse(updated)
+        except Exception:
+            pass
+
+    return guid, title, link, summary, published, created_dt, updated_dt
 
 
 def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
@@ -126,43 +139,32 @@ def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
 
     items_iter = getattr(items, "entries", items)
 
-    for item in items_iter:
-        guid, title, link, summary, published, updated = _parse_entry(item)
+    try:
+        with session.begin():
+            for item in items_iter:
+                guid, title, link, summary, published, created_dt, updated_dt = _parse_entry(item)
 
-        created_dt = None
-        updated_dt = None
-        if published:
-            try:
-                created_dt = parser.parse(published)
-            except Exception:
-                pass
-        if updated:
-            try:
-                updated_dt = parser.parse(updated)
-            except Exception:
-                pass
+                post = Post(
+                    id=guid,
+                    title=title,
+                    link=link,
+                    summary=summary,
+                    published=published,
+                    created_at=created_dt,
+                    updated_at=updated_dt,
+                )
 
-        post = Post(
-            id=guid,
-            title=title,
-            link=link,
-            summary=summary,
-            published=published,
-            created_at=created_dt,
-            updated_at=updated_dt,
-        )
-        session.add(post)
-        try:
-            session.commit()
-            logger.info("Saved post: %s", title)
-        except IntegrityError:
-            session.rollback()
-            logger.info("Skipping existing post: %s", title)
-        except Exception as exc:
-            session.rollback()
-            logger.error("Failed to save post %s: %s", title, exc)
-
-    session.close()
+                try:
+                    with session.begin_nested():
+                        session.add(post)
+                        session.flush()
+                    logger.info("Saved post: %s", title)
+                except IntegrityError:
+                    logger.info("Skipping existing post: %s", title)
+                except Exception as exc:
+                    logger.error("Failed to save post %s: %s", title, exc)
+    finally:
+        session.close()
 
 
 def main():

--- a/tests/test_feed_parsing.py
+++ b/tests/test_feed_parsing.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from bs4 import BeautifulSoup
 import requests
+from dateutil import parser
 from auto.feeds.ingestion import _parse_entry, fetch_feed
 
 
@@ -27,7 +28,8 @@ def test_parse_entry_from_soup():
         "http://example.com",
         "Summary",
         "Mon, 01 Jan 2000 00:00:00 +0000",
-        "",
+        parser.parse("Mon, 01 Jan 2000 00:00:00 +0000"),
+        None,
     )
 
 
@@ -47,7 +49,8 @@ def test_parse_entry_from_dummy_object():
         "http://dummy",
         "Body",
         "2025-01-01",
-        "2025-02-01",
+        parser.parse("2025-01-01"),
+        parser.parse("2025-02-01"),
     )
 
 


### PR DESCRIPTION
## Summary
- migrate database by applying all migration heads
- save RSS entries in one session using nested transactions for duplicate handling
- parse published/updated dates inside `_parse_entry` and test datetimes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876760a4778832a8be5476a491b348d