### PR TITLE
Fix Mastodon env resolution

### DIFF
--- a/src/auto/socials/mastodon_client.py
+++ b/src/auto/socials/mastodon_client.py
@@ -1,11 +1,16 @@
 from mastodon import Mastodon
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 from pathlib import Path
 import logging
 import os
 
-# Load environment variables from the project root .env file
-BASE_DIR = Path(__file__).resolve().parents[2]
+# Resolve the repository root so we can load the correct .env file
+dotenv_path = find_dotenv()
+BASE_DIR = (
+    Path(dotenv_path).resolve().parent
+    if dotenv_path
+    else Path(__file__).resolve().parents[3]
+)
 load_dotenv(BASE_DIR / ".env")
 
 MASTODON_INSTANCE = os.getenv("MASTODON_INSTANCE", "https://mastodon.social")


### PR DESCRIPTION
## Summary
- use `find_dotenv()` to locate the project `.env`
- load that file before reading variables

## Testing
- `pre-commit run --files src/auto/socials/mastodon_client.py`
- `pytest -q` *(fails: Multiple head revisions are present)*

------
https://chatgpt.com/codex/tasks/task_e_687675ef9790832abf7921c92e626580