### PR TITLE
Fix env config retrieval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,3 @@
 Use the main db.py connection whenever possible
 Use sqlalchemy models instead of sql statements when possible
+Avoid reading environment variables at import time; retrieve them within functions so changes take effect without restarting.

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
 - Containerize the application with a Dockerfile.
 
 ## Code Smells
-- Environment variables like SUBSTACK_FEED_URL are read during module import, so changes after startup have no effect.
 - Database sessions are sometimes manually closed instead of using a context manager.
 - Logging configuration occurs in __init__.py during import, which can interfere with embedding in other applications.
 - scheduler.py stores global state in the `_task` variable which can lead to race conditions if start() is called multiple times.

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -5,13 +5,10 @@ from .feeds.ingestion import init_db, fetch_feed, save_entries
 from . import scheduler
 from dotenv import load_dotenv
 import logging
-import os
 
 load_dotenv()
 logger = logging.getLogger(__name__)
 
-FEED_URL = os.getenv("SUBSTACK_FEED_URL")
-DB_URL   = os.getenv("DATABASE_URL")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -22,7 +19,9 @@ async def lifespan(app: FastAPI):
     finally:
         await scheduler.stop()
 
+
 app = FastAPI(lifespan=lifespan)
+
 
 @app.post("/ingest")
 async def ingest(background_tasks: BackgroundTasks):
@@ -30,10 +29,10 @@ async def ingest(background_tasks: BackgroundTasks):
     background_tasks.add_task(run_ingest)
     return {"status": "ingestion queued"}
 
+
 def run_ingest():
     try:
-        items = fetch_feed(FEED_URL)
+        items = fetch_feed()
         save_entries(items)
     except Exception as exc:
         logger.error("Ingestion failed: %s", exc)
-

--- a/tests/test_feed_parsing.py
+++ b/tests/test_feed_parsing.py
@@ -78,10 +78,6 @@ def test_fetch_feed_returns_items(monkeypatch):
 def test_fetch_feed_uses_env_variable(monkeypatch):
     """fetch_feed() should use SUBSTACK_FEED_URL when no URL is provided."""
     monkeypatch.setenv("SUBSTACK_FEED_URL", "http://env.example/feed")
-    # reload module so FEED_URL picks up env var
-    import importlib
-    import auto.feeds.ingestion as ingestion_module
-    importlib.reload(ingestion_module)
 
     called = {}
 
@@ -97,8 +93,9 @@ def test_fetch_feed_uses_env_variable(monkeypatch):
         called["url"] = url
         return DummyResponse()
 
-    monkeypatch.setattr(ingestion_module.requests, "get", fake_get)
+    monkeypatch.setattr("auto.feeds.ingestion.requests.get", fake_get)
+
+    from auto.feeds import ingestion as ingestion_module
 
     ingestion_module.fetch_feed()
     assert called.get("url") == "http://env.example/feed"
-


### PR DESCRIPTION
## Summary
- lazily read SUBSTACK_FEED_URL instead of capturing at import time
- adjust ingestion and API to use the lazy getter
- update tests for new behaviour
- document avoiding import-time env reads in AGENTS.md
- trim TODO item about env var code smell

## Testing
- `pre-commit run --files AGENTS.md TODO.md src/auto/feeds/ingestion.py src/auto/main.py tests/test_api_ingest.py tests/test_feed_parsing.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ae516f78832a890ff1b7da5de07c