### PR TITLE
Fix DB session management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 Use the main db.py connection whenever possible
 Use sqlalchemy models instead of sql statements when possible
 Avoid reading environment variables at import time; retrieve them within functions so changes take effect without restarting.
+Use context managers for database sessions instead of calling ``session.close()`` manually.

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
 - Containerize the application with a Dockerfile.
 
 ## Code Smells
-- Database sessions are sometimes manually closed instead of using a context manager.
 - Logging configuration occurs in __init__.py during import, which can interfere with embedding in other applications.
 - scheduler.py stores global state in the `_task` variable which can lead to race conditions if start() is called multiple times.
 - Parsing logic in feeds/ingestion.py has many branches and could be simplified or documented better.

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -150,11 +150,9 @@ def _parse_entry(item):
 
 def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
     """Save new entries from the feed into the database."""
-    session = _session_for_path(db_path, engine=engine, session_factory=session_factory)
-
     items_iter = getattr(items, "entries", items)
 
-    try:
+    with _session_for_path(db_path, engine=engine, session_factory=session_factory) as session:
         with session.begin():
             for item in items_iter:
                 guid, title, link, summary, published, created_dt, updated_dt = (
@@ -180,8 +178,6 @@ def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
                     logger.info("Skipping existing post: %s", title)
                 except Exception as exc:
                     logger.error("Failed to save post %s: %s", title, exc)
-    finally:
-        session.close()
 
 
 def main():


### PR DESCRIPTION
## Summary
- manage sessions with context managers in ingestion
- remove manual `session.close()` smell from TODO
- advise to use context managers for DB sessions in AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b0055f60832abe7017b2a2bc59b1