### PR TITLE
Address logging config smell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@ Use the main db.py connection whenever possible
 Use sqlalchemy models instead of sql statements when possible
 Avoid reading environment variables at import time; retrieve them within functions so changes take effect without restarting.
 Use context managers for database sessions instead of calling ``session.close()`` manually.
+Configure logging in an explicit function and invoke it during application startup instead of at import time.

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
 - Containerize the application with a Dockerfile.
 
 ## Code Smells
-- Logging configuration occurs in __init__.py during import, which can interfere with embedding in other applications.
 - scheduler.py stores global state in the `_task` variable which can lead to race conditions if start() is called multiple times.
 - Parsing logic in feeds/ingestion.py has many branches and could be simplified or documented better.
 - Config values like POLL_INTERVAL and POST_DELAY are set at import time and do not pick up environment changes.

--- a/src/auto/__init__.py
+++ b/src/auto/__init__.py
@@ -1,7 +1,16 @@
 import logging
 import os
 
-logging.basicConfig(
-    level=os.getenv("LOG_LEVEL", "INFO"),
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-)
+
+def configure_logging() -> None:
+    """Configure application logging.
+
+    Reads the desired log level from the ``LOG_LEVEL`` environment variable
+    when invoked so environment changes take effect without restarting.
+    """
+
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO"),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -2,16 +2,17 @@
 from fastapi import FastAPI, BackgroundTasks
 from contextlib import asynccontextmanager
 from .feeds.ingestion import init_db, fetch_feed, save_entries
-from . import scheduler
+from . import scheduler, configure_logging
 from dotenv import load_dotenv
 import logging
 
-load_dotenv()
 logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    load_dotenv()
+    configure_logging()
     init_db()
     await scheduler.start()
     try:


### PR DESCRIPTION
## Summary
- refactor logging configuration so it isn't executed at import time
- initialize logging in `lifespan`
- document logging guidance in `AGENTS.md`
- remove resolved code smell from `TODO.md`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b27328f4832a8ff99bb9d97ea64a