### PR TITLE
Implement linting in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,12 @@ repos:
       - id: black
         language_version: python3
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.3
+    hooks:
+      - id: ruff
+        args: [--fix]
+
   - repo: local
     hooks:
       - id: alembic-check-heads

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ post’s publish status per network is tracked in the `post_status` table.
 While minimal, the goal is to provide the scaffolding for mirroring your
 Substack content across multiple social sites with a single workflow.
 
+## Development
+
+Install the pre-commit hooks so formatting and linting run automatically:
+
+```bash
+pre-commit install
+```
+
 ## License
 
 Distributed under the [MIT License](LICENSE).

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## High Priority
 
 ## Medium Priority
-- Set up linting to run automatically on pre-commit.
 - Implement periodic/scheduled ingestion instead of manual triggering.
 
 ## Low Priority

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest",
+  "ruff",
 ]
 
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-magic==0.4.27
 requests==2.32.4
+ruff==0.12.3
 setuptools==80.4.0
 sgmllib3k==1.0.0
 six==1.17.0


### PR DESCRIPTION
## Summary
- add `ruff` linter to pre-commit configuration
- include `ruff` as a development dependency and pin it in requirements
- document pre-commit usage in README
- remove completed TODO item

## Testing
- `pre-commit run --files .pre-commit-config.yaml pyproject.toml requirements.txt README.md TODO.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876bc99ea80832aac94ead4f790b6ca