### PR TITLE
Add quick_post task

### DIFF
--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -24,7 +24,11 @@ async def _publish(status: PostStatus, session):
         return
     try:
         if status.network == "mastodon":
-            await asyncio.to_thread(post_to_mastodon, f"{post.title} {post.link}")
+            await asyncio.to_thread(
+                post_to_mastodon,
+                f"{post.title} {post.link}",
+                visibility="unlisted",
+            )
         else:
             raise ValueError(f"Unsupported network {status.network}")
         status.status = "published"

--- a/tests/test_quick_post.py
+++ b/tests/test_quick_post.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+from invoke import Context
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT))
+
+import tasks  # noqa: E402
+from sqlalchemy import create_engine
+from auto.feeds.ingestion import init_db
+from auto.db import SessionLocal
+from auto.models import Post, PostStatus
+
+
+def setup_db(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    init_db(str(db_path), engine=engine)
+    SessionLocal.configure(bind=engine)
+    return engine
+
+
+def test_quick_post_schedules(monkeypatch, tmp_path):
+    setup_db(tmp_path)
+    with SessionLocal() as session:
+        session.add(Post(id="1", title="One", link="http://1", summary="", published="2000"))
+        session.add(Post(id="2", title="Two", link="http://2", summary="", published="1999"))
+        session.add(PostStatus(post_id="1", network="mastodon", status="published"))
+        session.commit()
+
+    monkeypatch.setattr("builtins.input", lambda prompt='': 'y')
+
+    tasks.quick_post(Context())
+
+    with SessionLocal() as session:
+        ps = session.get(PostStatus, {"post_id": "2", "network": "mastodon"})
+        assert ps is not None
+        assert ps.status == "pending"
+
+
+def test_quick_post_abort(monkeypatch, tmp_path):
+    setup_db(tmp_path)
+    with SessionLocal() as session:
+        session.add(Post(id="1", title="One", link="http://1", summary="", published="2000"))
+        session.commit()
+
+    monkeypatch.setattr("builtins.input", lambda prompt='': 'n')
+
+    tasks.quick_post(Context())
+
+    with SessionLocal() as session:
+        statuses = session.query(PostStatus).all()
+        assert statuses == []

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -38,7 +38,10 @@ def test_process_pending_publishes(tmp_path, monkeypatch):
         session.add(status)
         session.commit()
 
-    monkeypatch.setattr("auto.scheduler.post_to_mastodon", lambda text: DummyPoster.post(text))
+    monkeypatch.setattr(
+        "auto.scheduler.post_to_mastodon",
+        lambda text, visibility="unlisted": DummyPoster.post(text),
+    )
 
     asyncio.run(process_pending())
 


### PR DESCRIPTION
## Summary
- implement a quick_post invoke task to schedule the oldest unshared post
- publish posts as unlisted when the scheduler runs
- test the new task
- update scheduler tests for new visibility argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e94f4bf8832abe9e167cb54e4cd4