### PR TITLE
Add Mastodon trending tags command

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -142,3 +142,23 @@ def quick_post(ctx, network="mastodon"):
         return
 
     schedule(ctx, post_id=post.id, time="in 1m", network=network)
+
+
+@task
+def trending_tags(ctx, limit=10, instance=None, token=None):
+    """Display trending tags from Mastodon."""
+    import os
+    from dotenv import load_dotenv, find_dotenv
+    from mastodon import Mastodon
+
+    load_dotenv(find_dotenv())
+
+    instance = instance or os.getenv("MASTODON_INSTANCE", "https://mastodon.social")
+    token = token or os.getenv("MASTODON_TOKEN")
+
+    masto = Mastodon(access_token=token, api_base_url=instance)
+    tags = masto.trending_tags(limit=limit)
+
+    for tag in tags:
+        name = tag["name"] if isinstance(tag, dict) else getattr(tag, "name", str(tag))
+        print(name)

--- a/tests/test_trending_tags.py
+++ b/tests/test_trending_tags.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+from invoke import Context
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT))
+
+import tasks  # noqa: E402
+import mastodon  # noqa: E402
+
+
+def test_trending_tags_outputs(monkeypatch, capsys):
+    class DummyMastodon:
+        def trending_tags(self, limit=None):
+            return [{"name": "python"}, {"name": "coding"}]
+
+    monkeypatch.setattr(mastodon, "Mastodon", lambda **_: DummyMastodon())
+
+    tasks.trending_tags(Context(), limit=2)
+
+    captured = capsys.readouterr()
+    assert "python" in captured.out
+    assert "coding" in captured.out


### PR DESCRIPTION
## Summary
- add an `invoke` task to show Mastodon trending tags
- test that the task prints the tags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e9db22a0832abedf25156b84af20