### PR TITLE
Add chat task for local LLM

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ uvicorn==0.35.0
 virtualenv==20.31.2
 wheel==0.45.1
 pre-commit==4.2.0
+dspy==2.6.27

--- a/tasks.py
+++ b/tasks.py
@@ -125,12 +125,7 @@ def quick_post(ctx, network="mastodon"):
         .exists()
     )
 
-    stmt = (
-        select(Post)
-        .where(~exists_stmt)
-        .order_by(Post.created_at)
-        .limit(1)
-    )
+    stmt = select(Post).where(~exists_stmt).order_by(Post.created_at).limit(1)
 
     with SessionLocal() as session:
         post = session.execute(stmt).scalars().first()
@@ -167,3 +162,28 @@ def trending_tags(ctx, limit=10, instance=None, token=None):
     for tag in tags:
         name = tag["name"] if isinstance(tag, dict) else getattr(tag, "name", str(tag))
         print(name)
+
+
+@task
+def chat(
+    ctx,
+    message=None,
+    model="gemma-3-27b-it-qat",
+    api_base="http://localhost:1234/v1",
+    model_type="chat",
+):
+    """Send a chat message to a local LLM via dspy."""
+    import dspy
+
+    lm = dspy.LM(
+        model=model,
+        api_base=api_base,
+        api_key="",
+        model_type=model_type,
+    )
+    dspy.configure(lm=lm)
+
+    default_question = "What is the typical silica (SiO₂) content in standard soda-lime glass, and how is it manufactured?"
+    prompt = message or default_question
+    response = dspy.chat(prompt)
+    print(response)


### PR DESCRIPTION
## Summary
- support dspy for local LLM usage
- add `invoke chat` task to send a prompt to a local model

## Testing
- `pre-commit run --files tasks.py requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ea67a18c832a9181f3eb7036e827