### PR TITLE
Refactor DB engine access via helper functions

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -2,7 +2,7 @@ import os
 from dotenv import load_dotenv
 from alembic import context
 from logging.config import fileConfig
-from auto.db import engine as db_engine
+from auto.db import get_engine
 
 # find the project root (one directory above alembic/)
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
@@ -64,7 +64,7 @@ def run_migrations_online() -> None:
     connectable = config.attributes.get("connection")
 
     if connectable is None:
-        connectable = db_engine
+        connectable = get_engine()
 
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)


### PR DESCRIPTION
## Summary
- define `get_database_url()` and `get_engine()` in `db.py`
- create `SessionLocal()` that uses `get_engine()`
- switch scheduler and alembic env to call the new helpers
- update tests to patch `get_engine`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876fc28a594832a93757d2ef6ba6202