### PR TITLE
Add scheduler env vars to docs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,3 +10,9 @@ MASTODON_TOKEN=YOUR_ACCESS_TOKEN_HERE
 
 # Number of times to attempt publishing a post before giving up
 MAX_ATTEMPTS=3
+
+# How often the scheduler checks for posts to publish
+SCHEDULER_POLL_INTERVAL=5
+
+# Delay between individual publish attempts in seconds
+POST_DELAY=1

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The following variables are used:
   `https://mastodon.social`.
 - `MASTODON_TOKEN` – access token for posting to Mastodon.
 - `MAX_ATTEMPTS` – maximum number of publish attempts before giving up.
+- `SCHEDULER_POLL_INTERVAL` – how often the scheduler checks for posts, in
+  seconds.
+- `POST_DELAY` – delay between individual publish attempts in seconds.
 
 ## Running the server
 


### PR DESCRIPTION
## Summary
- add scheduler poll interval and post delay settings
- document their purpose in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876fcbc4e04832a904dc237c2d3bf36