### PR TITLE
Add medium automation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,5 +8,9 @@ DATABASE_URL=sqlite:///./substack.db
 MASTODON_INSTANCE=https://mastodon.social
 MASTODON_TOKEN=YOUR_ACCESS_TOKEN_HERE
 
+# Credentials for browser automation with Medium
+MEDIUM_EMAIL=you@example.com
+MEDIUM_PASSWORD=changeme
+
 # Number of times to attempt publishing a post before giving up
 MAX_ATTEMPTS=3

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The following variables are used:
 - `MASTODON_INSTANCE` – base URL of the Mastodon instance, default
   `https://mastodon.social`.
 - `MASTODON_TOKEN` – access token for posting to Mastodon.
+- `MEDIUM_EMAIL` – email address used to sign in to Medium.
+- `MEDIUM_PASSWORD` – password for the Medium account.
 - `MAX_ATTEMPTS` – maximum number of publish attempts before giving up.
 - `SCHEDULER_POLL_INTERVAL` – seconds between scheduler iterations,
   default `5`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "python-dotenv",
   "beautifulsoup4",
   "lxml",
+  "selenium",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ virtualenv==20.31.2
 wheel==0.45.1
 pre-commit==4.2.0
 dspy==2.6.27
+selenium>=4.0.0

--- a/src/auto/automation/medium.py
+++ b/src/auto/automation/medium.py
@@ -1,0 +1,42 @@
+import os
+import logging
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+logger = logging.getLogger(__name__)
+
+
+def _get_credentials():
+    """Return Medium login credentials from the environment."""
+    email = os.getenv("MEDIUM_EMAIL")
+    password = os.getenv("MEDIUM_PASSWORD")
+    if not email or not password:
+        raise ValueError("MEDIUM_EMAIL and MEDIUM_PASSWORD must be set")
+    return email, password
+
+
+class MediumClient:
+    """Automate basic Medium interactions using Selenium."""
+
+    def __init__(self, driver: webdriver.Firefox | None = None) -> None:
+        self.driver = driver or webdriver.Firefox()
+
+    def login(self) -> None:
+        """Sign in to Medium using credentials from the environment."""
+        email, password = _get_credentials()
+        try:
+            self.driver.get("https://medium.com/m/signin")
+            email_input = self.driver.find_element(By.NAME, "email")
+            email_input.send_keys(email)
+            email_input.send_keys(Keys.RETURN)
+            password_input = self.driver.find_element(By.NAME, "password")
+            password_input.send_keys(password)
+            password_input.send_keys(Keys.RETURN)
+            logger.info("Submitted Medium login form")
+        except Exception as exc:
+            logger.error("Failed to sign in to Medium: %s", exc)
+            raise
+
+    def close(self) -> None:
+        self.driver.quit()

--- a/tests/test_medium_client.py
+++ b/tests/test_medium_client.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from auto.automation.medium import MediumClient
+
+
+class DummyElement:
+    def __init__(self, calls, value):
+        self.calls = calls
+        self.value = value
+
+    def send_keys(self, keys):
+        self.calls.append(("send_keys", self.value, keys))
+
+    def click(self):
+        self.calls.append(("click", self.value))
+
+
+class DummyDriver:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url):
+        self.calls.append(("get", url))
+
+    def find_element(self, by, value):
+        self.calls.append(("find", by, value))
+        return DummyElement(self.calls, value)
+
+    def quit(self):
+        self.calls.append(("quit",))
+
+
+def test_login_uses_env(monkeypatch):
+    monkeypatch.setenv("MEDIUM_EMAIL", "user@example.com")
+    monkeypatch.setenv("MEDIUM_PASSWORD", "secret")
+    driver = DummyDriver()
+    client = MediumClient(driver=driver)
+    client.login()
+    assert ("get", "https://medium.com/m/signin") in driver.calls
+    assert ("send_keys", "email", "user@example.com") in driver.calls
+    assert ("send_keys", "password", "secret") in driver.calls

--- a/tests/test_quick_post.py
+++ b/tests/test_quick_post.py
@@ -8,10 +8,10 @@ sys.path.insert(0, str(ROOT / "src"))
 sys.path.insert(0, str(ROOT))
 
 import tasks  # noqa: E402
-from sqlalchemy import create_engine
-from auto.feeds.ingestion import init_db
-from auto.db import SessionLocal
-from auto.models import Post, PostStatus
+from sqlalchemy import create_engine  # noqa: E402
+from auto.feeds.ingestion import init_db  # noqa: E402
+from auto.db import SessionLocal  # noqa: E402
+from auto.models import Post, PostStatus  # noqa: E402
 
 
 def setup_db(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add MEDIUM_* vars for new platform
- scaffold `MediumClient` using Selenium
- add basic test for Medium login
- lint

## Testing
- `ruff check --fix .`
- `black src/auto/automation/medium.py tests/test_medium_client.py tests/test_quick_post.py --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ab7f3dd0832ab94e8c8d5675eb9d