### PR TITLE
Add Medium login integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ Install the pre-commit hooks so formatting and linting run automatically:
 pre-commit install
 ```
 
+## Running tests
+
+Run the unit test suite with `pytest`. Integration tests are skipped by
+default because they require real credentials and network access. To run
+them, set `MEDIUM_EMAIL` and `MEDIUM_PASSWORD` and pass the `integration`
+marker:
+
+```bash
+pytest -m integration
+```
+
 ## License
 
 Distributed under the [MIT License](LICENSE).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: tests that perform real network operations
+addopts = -m "not integration"

--- a/tests/test_medium_login_integration.py
+++ b/tests/test_medium_login_integration.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+from selenium import webdriver
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from auto.automation.medium import MediumClient  # noqa: E402
+
+
+@pytest.mark.integration
+def test_medium_login_real():
+    """Verify that Medium login succeeds with real credentials."""
+    email = os.getenv("MEDIUM_EMAIL")
+    password = os.getenv("MEDIUM_PASSWORD")
+    if not email or not password:
+        pytest.skip("MEDIUM_EMAIL and MEDIUM_PASSWORD must be set")
+
+    options = webdriver.FirefoxOptions()
+    options.add_argument("-headless")
+    driver = webdriver.Firefox(options=options)
+
+    client = MediumClient(driver=driver)
+    try:
+        client.login()
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary
- add test for real Medium login marked as integration
- skip integration tests by default via pytest.ini
- document running integration tests in README

## Testing
- `pytest -q`
- `pytest -m integration -q`

------
https://chatgpt.com/codex/tasks/task_e_6877aded2154832a9b12ca750073619b