### PR TITLE
Add Safari tab automation

### DIFF
--- a/scripts/safari_fill.scpt
+++ b/scripts/safari_fill.scpt
@@ -1,0 +1,34 @@
+on run argv
+    if (count of argv) is less than 3 then
+        return "usage: safari_fill.scpt url selector text"
+    end if
+    set targetUrl to item 1 of argv
+    set cssSelector to item 2 of argv
+    set textValue to item 3 of argv
+
+    tell application "Safari"
+        activate
+        set foundTab to false
+        repeat with w in every window
+            repeat with t in every tab of w
+                if (URL of t) is targetUrl then
+                    set current tab of w to t
+                    set index of w to 1
+                    set foundTab to true
+                    exit repeat
+                end if
+            end repeat
+            if foundTab then exit repeat
+        end repeat
+        if not foundTab then
+            if (count of windows) is 0 then
+                make new document
+            end if
+            set newTab to make new tab at end of tabs of window 1
+            set URL of newTab to targetUrl
+            set current tab of window 1 to newTab
+        end if
+        delay 1
+        do JavaScript "var el=document.querySelector('" & cssSelector & "');if(el){el.focus();el.value='" & textValue & "';}" in current tab of window 1
+    end tell
+end run

--- a/tasks.py
+++ b/tasks.py
@@ -213,3 +213,24 @@ def medium_magic_link(ctx):
         print(f"Found magic link: {link}")
     else:
         print("Magic link not found")
+
+
+def _fill_safari_tab(url: str, selector: str, text: str) -> None:
+    """Open Safari to ``url`` and fill ``selector`` with ``text``."""
+    import subprocess
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parent / "scripts" / "safari_fill.scpt"
+    result = subprocess.run(
+        ["osascript", str(script), url, selector, text],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+
+
+@task
+def safari_fill(ctx, url, selector, text):
+    """Open or activate a Safari tab and type text into the given field."""
+    _fill_safari_tab(url, selector, text)


### PR DESCRIPTION
## Summary
- add `safari_fill.scpt` to open or activate a Safari tab
- add `_fill_safari_tab` helper and `safari_fill` Invoke task

## Testing
- `pre-commit run --files tasks.py scripts/safari_fill.scpt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b6f6646c832ab7cb66873d205114