### PR TITLE
Improve test instructions and preflight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,13 @@ pre-commit install
 
 ## Running tests
 
-Run the unit test suite with `pytest`. Integration tests are skipped by
+Before running tests, install the project dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then run the unit test suite with `pytest`. Integration tests are skipped by
 default because they require real credentials and network access. To run
 them, set `MEDIUM_EMAIL` and `MEDIUM_PASSWORD` and pass the `integration`
 marker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
 dev = [
   "pytest",
   "ruff",
+  "black",
+  "pre-commit",
+  "invoke",
+  "dspy",
 ]
 
 [build-system]

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     integration: tests that perform real network operations
 addopts = -m "not integration"
+# Dependencies are checked in tests/conftest.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import pkg_resources
+from pathlib import Path
+import pytest
+
+
+def _check_dependencies() -> None:
+    requirements_file = Path(__file__).resolve().parents[1] / "requirements.txt"
+    missing = []
+    for line in requirements_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            pkg_resources.require(line)
+        except Exception:
+            missing.append(line)
+    if missing:
+        pytest.exit(
+            "Missing dependencies: "
+            + ", ".join(missing)
+            + ".\nRun 'pip install -r requirements.txt' before running tests.",
+            returncode=1,
+        )
+
+
+def pytest_configure(config):
+    _check_dependencies()


### PR DESCRIPTION
## Summary
- document installing dependencies before running tests
- add a dependency check in tests via `conftest.py`
- mention the check in `pytest.ini`
- declare dev dependencies in `pyproject.toml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877bc62bccc832a9915b0b70861bf72