### PR TITLE
Fix Mastodon client imports

### DIFF
--- a/src/auto/socials/mastodon_client.py
+++ b/src/auto/socials/mastodon_client.py
@@ -1,5 +1,6 @@
 from mastodon import Mastodon
 from dotenv import load_dotenv, find_dotenv
+from pathlib import Path
 import logging
 import os
 


### PR DESCRIPTION
## Summary
- add missing `Path` import for Mastodon client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877c4d9a0b8832a8f4af9b1d00dadd4