### PR TITLE
Centralize env configuration

### DIFF
--- a/src/auto/automation/medium.py
+++ b/src/auto/automation/medium.py
@@ -1,16 +1,17 @@
-import os
 import logging
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+
+from ..config import get_medium_email, get_medium_password
 
 logger = logging.getLogger(__name__)
 
 
 def _get_credentials():
     """Return Medium login credentials from the environment."""
-    email = os.getenv("MEDIUM_EMAIL")
-    password = os.getenv("MEDIUM_PASSWORD")
+    email = get_medium_email()
+    password = get_medium_password()
     if not email or not password:
         raise ValueError("MEDIUM_EMAIL and MEDIUM_PASSWORD must be set")
     return email, password

--- a/src/auto/config.py
+++ b/src/auto/config.py
@@ -1,0 +1,62 @@
+import os
+from dotenv import load_dotenv, find_dotenv
+
+DEFAULT_FEED_URL = "https://geoffreyducharme.substack.com/feed"
+
+_loaded = False
+
+def load_env() -> None:
+    """Load environment variables from the nearest ``.env`` file once."""
+    global _loaded
+    if not _loaded:
+        dotenv_path = find_dotenv()
+        if dotenv_path:
+            load_dotenv(dotenv_path)
+        else:
+            load_dotenv()
+        _loaded = True
+
+
+def get_database_url() -> str:
+    load_env()
+    return os.getenv("DATABASE_URL", "sqlite:///./substack.db")
+
+
+def get_feed_url() -> str:
+    load_env()
+    return os.getenv("SUBSTACK_FEED_URL", DEFAULT_FEED_URL)
+
+
+def get_mastodon_instance() -> str:
+    load_env()
+    return os.getenv("MASTODON_INSTANCE", "https://mastodon.social")
+
+
+def get_mastodon_token() -> str | None:
+    load_env()
+    return os.getenv("MASTODON_TOKEN")
+
+
+def get_poll_interval() -> int:
+    load_env()
+    return int(os.getenv("SCHEDULER_POLL_INTERVAL", "5"))
+
+
+def get_post_delay() -> float:
+    load_env()
+    return float(os.getenv("POST_DELAY", "1"))
+
+
+def get_max_attempts() -> int:
+    load_env()
+    return int(os.getenv("MAX_ATTEMPTS", "3"))
+
+
+def get_medium_email() -> str | None:
+    load_env()
+    return os.getenv("MEDIUM_EMAIL")
+
+
+def get_medium_password() -> str | None:
+    load_env()
+    return os.getenv("MEDIUM_PASSWORD")

--- a/src/auto/db.py
+++ b/src/auto/db.py
@@ -2,16 +2,12 @@
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
-import os
-from dotenv import load_dotenv
+
+from .config import get_database_url
 
 _engine = None
 
 
-def get_database_url() -> str:
-    """Return the database URL from ``DATABASE_URL`` or the default."""
-    load_dotenv()
-    return os.getenv("DATABASE_URL", "sqlite:///./substack.db")
 
 
 def get_engine():

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import requests
 from typing import Optional
 from bs4 import BeautifulSoup
@@ -13,18 +12,9 @@ from sqlalchemy.exc import IntegrityError
 from ..db import SessionLocal
 
 from ..models import Post
-
-from dotenv import load_dotenv
+from ..config import load_env, get_feed_url
 logger = logging.getLogger(__name__)
 
-# Configuration
-DEFAULT_FEED_URL = "https://geoffreyducharme.substack.com/feed"
-
-
-def get_feed_url() -> str:
-    """Return the feed URL from ``SUBSTACK_FEED_URL`` or the default."""
-    load_dotenv()
-    return os.getenv("SUBSTACK_FEED_URL", DEFAULT_FEED_URL)
 
 
 # Determine project root four directories above this file
@@ -161,7 +151,7 @@ def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
 
 
 def main():
-    load_dotenv()
+    load_env()
     init_db()
     items = fetch_feed()
     save_entries(items)

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI, BackgroundTasks
 from contextlib import asynccontextmanager
 from .feeds.ingestion import init_db, fetch_feed, save_entries
 from . import scheduler, configure_logging
-from dotenv import load_dotenv
+from .config import load_env
 import logging
 
 logger = logging.getLogger(__name__)
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    load_dotenv()
+    load_env()
     configure_logging()
     init_db()
     await scheduler.start()

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -11,23 +10,11 @@ from sqlalchemy import and_, or_
 from .db import SessionLocal, get_engine
 from .models import PostStatus, Post, PostPreview
 from .socials.mastodon_client import post_to_mastodon
+from .config import get_poll_interval, get_post_delay, get_max_attempts
 
 logger = logging.getLogger(__name__)
 
 
-def get_poll_interval() -> int:
-    """Return the scheduler poll interval in seconds."""
-    return int(os.getenv("SCHEDULER_POLL_INTERVAL", "5"))
-
-
-def get_post_delay() -> float:
-    """Return the delay between publish attempts."""
-    return float(os.getenv("POST_DELAY", "1"))
-
-
-def get_max_attempts() -> int:
-    """Return the maximum publish attempts."""
-    return int(os.getenv("MAX_ATTEMPTS", "3"))
 
 
 async def _publish(status: PostStatus, session):

--- a/src/auto/socials/mastodon_client.py
+++ b/src/auto/socials/mastodon_client.py
@@ -1,49 +1,9 @@
 from mastodon import Mastodon
-from dotenv import load_dotenv, find_dotenv
-from pathlib import Path
 import logging
-import os
 
-# Resolve the repository root so we can load the correct .env file
-dotenv_path = find_dotenv()
-BASE_DIR = (
-    Path(dotenv_path).resolve().parent
-    if dotenv_path
-    else Path(__file__).resolve().parents[3]
-)
-
-
-def get_mastodon_instance() -> str:
-    """Return the Mastodon instance URL from the environment."""
-    load_dotenv(BASE_DIR / ".env")
-    return os.getenv("MASTODON_INSTANCE", "https://mastodon.social")
-
-
-def get_mastodon_token() -> str | None:
-    """Return the Mastodon access token from the environment."""
-    load_dotenv(BASE_DIR / ".env")
-    return os.getenv("MASTODON_TOKEN")
+from ..config import get_mastodon_instance, get_mastodon_token
 
 logger = logging.getLogger(__name__)
-
-
-def _load_env() -> None:
-    """Load environment variables from the nearest ``.env`` file."""
-    dotenv_path = find_dotenv()
-    if dotenv_path:
-        load_dotenv(dotenv_path)
-
-
-def get_instance() -> str:
-    """Return the Mastodon instance URL."""
-    _load_env()
-    return os.getenv("MASTODON_INSTANCE", "https://mastodon.social")
-
-
-def get_access_token() -> str:
-    """Return the Mastodon access token."""
-    _load_env()
-    return os.getenv("MASTODON_TOKEN")
 
 
 def post_to_mastodon(status: str, visibility: str = "private") -> None:

--- a/tasks.py
+++ b/tasks.py
@@ -147,14 +147,13 @@ def quick_post(ctx, network="mastodon"):
 @task
 def trending_tags(ctx, limit=10, instance=None, token=None):
     """Display trending tags from Mastodon."""
-    import os
-    from dotenv import load_dotenv, find_dotenv
     from mastodon import Mastodon
+    from auto.config import load_env, get_mastodon_instance, get_mastodon_token
 
-    load_dotenv(find_dotenv())
+    load_env()
 
-    instance = instance or os.getenv("MASTODON_INSTANCE", "https://mastodon.social")
-    token = token or os.getenv("MASTODON_TOKEN")
+    instance = instance or get_mastodon_instance()
+    token = token or get_mastodon_token()
 
     masto = Mastodon(access_token=token, api_base_url=instance)
     tags = masto.trending_tags(limit=limit)


### PR DESCRIPTION
## Summary
- create `auto.config` module for environment handling
- update db, ingestion, main and scheduler to use centralized config
- update Mastodon and Medium helpers to read config via new module
- refactor `trending_tags` task to load environment once

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c6086fa0832aa3a6065a4bac277b