### PR TITLE
Fix updated_at columns

### DIFF
--- a/src/auto/models.py
+++ b/src/auto/models.py
@@ -1,6 +1,9 @@
+from datetime import datetime
+
 from sqlalchemy import Column, String, Text, Integer, DateTime, ForeignKey, text
 
 from .db import Base
+
 
 class Post(Base):
     __tablename__ = "posts"
@@ -10,8 +13,18 @@ class Post(Base):
     link = Column(String, nullable=False)
     summary = Column(Text)
     published = Column(String)
-    created_at = Column(DateTime)
-    updated_at = Column(DateTime)
+    created_at = Column(
+        DateTime,
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+        onupdate=datetime.utcnow,
+    )
+
 
 class PostStatus(Base):
     __tablename__ = "post_status"
@@ -30,6 +43,7 @@ class PostStatus(Base):
         DateTime,
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
+        onupdate=datetime.utcnow,
     )
 
 
@@ -43,4 +57,5 @@ class PostPreview(Base):
         DateTime,
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
+        onupdate=datetime.utcnow,
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,60 @@
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from auto.feeds.ingestion import init_db
+from auto.db import SessionLocal
+from auto.models import Post, PostStatus, PostPreview
+
+
+def test_updated_at_refreshes(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    init_db(str(db_path), engine=engine)
+
+    monkeypatch.setattr("auto.db.get_engine", lambda: engine)
+
+    earlier = datetime.utcnow() - timedelta(days=1)
+
+    with SessionLocal() as session:
+        post = Post(
+            id="1",
+            title="Title",
+            link="http://example",
+            created_at=earlier,
+            updated_at=earlier,
+        )
+        status = PostStatus(
+            post_id="1",
+            network="mastodon",
+            scheduled_at=datetime.utcnow(),
+            updated_at=earlier,
+        )
+        preview = PostPreview(
+            post_id="1",
+            network="mastodon",
+            content="text",
+            updated_at=earlier,
+        )
+        session.add_all([post, status, preview])
+        session.commit()
+
+        old_post_ts = post.updated_at
+        old_status_ts = status.updated_at
+        old_preview_ts = preview.updated_at
+
+        # modify rows
+        post.summary = "new"
+        status.status = "published"
+        preview.content = "newtext"
+        session.commit()
+
+        assert post.updated_at > old_post_ts
+        assert status.updated_at > old_status_ts
+        assert preview.updated_at > old_preview_ts


### PR DESCRIPTION
## Summary
- keep updated_at timestamps fresh by adding onupdate callbacks
- test that updated_at timestamps change when rows are modified

## Testing
- `pre-commit run --files src/auto/models.py tests/test_models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877ccfd3760832a88e07e2610c9ba68