### PR TITLE
Centralize dotenv initialization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@
 - Config values like POLL_INTERVAL and POST_DELAY are set at import time and do not pick up environment changes.
 
 ## DRY
-- ``load_dotenv`` is called in multiple modules (``db.py``, ``ingestion.py``, ``main.py``, ``mastodon_client.py``, ``tasks.py``). Centralize environment loading so configuration happens once.
 - Several helpers fetch config values from ``os.getenv`` with defaults – e.g. ``get_feed_url``, ``get_database_url``, ``get_instance``, ``get_poll_interval``. Consider a unified configuration module.
 - Tests repeatedly set up a temporary SQLite database with ``create_engine`` and ``init_db`` while monkeypatching ``auto.db.get_engine``. Provide a fixture to share this logic.
 - ``DummyResponse`` classes for mocking ``requests.get`` appear in multiple test files. Factor them into a common helper.

--- a/src/auto/__init__.py
+++ b/src/auto/__init__.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from .config import load_env
+
 
 def configure_logging() -> None:
     """Configure application logging.
@@ -9,6 +11,7 @@ def configure_logging() -> None:
     when invoked so environment changes take effect without restarting.
     """
 
+    load_env()
     logging.basicConfig(
         level=os.getenv("LOG_LEVEL", "INFO"),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -151,7 +151,6 @@ def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
 
 
 def main():
-    load_env()
     init_db()
     items = fetch_feed()
     save_entries(items)

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -3,7 +3,6 @@ from fastapi import FastAPI, BackgroundTasks
 from contextlib import asynccontextmanager
 from .feeds.ingestion import init_db, fetch_feed, save_entries
 from . import scheduler, configure_logging
-from .config import load_env
 import logging
 
 logger = logging.getLogger(__name__)
@@ -11,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    load_env()
     configure_logging()
     init_db()
     await scheduler.start()

--- a/tasks.py
+++ b/tasks.py
@@ -148,9 +148,7 @@ def quick_post(ctx, network="mastodon"):
 def trending_tags(ctx, limit=10, instance=None, token=None):
     """Display trending tags from Mastodon."""
     from mastodon import Mastodon
-    from auto.config import load_env, get_mastodon_instance, get_mastodon_token
-
-    load_env()
+    from auto.config import get_mastodon_instance, get_mastodon_token
 
     instance = instance or get_mastodon_instance()
     token = token or get_mastodon_token()


### PR DESCRIPTION
## Summary
- load `.env` automatically in `configure_logging`
- rely on config helpers to load environment variables
- remove `load_dotenv` entry from the TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ce8c4378832a917fd3fcd7a4d42a