### PR TITLE
Fix utcnow deprecation warnings

### DIFF
--- a/src/auto/models.py
+++ b/src/auto/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Column, String, Text, Integer, DateTime, ForeignKey, text
 
@@ -22,7 +22,7 @@ class Post(Base):
         DateTime,
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
-        onupdate=datetime.utcnow,
+        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
     )
 
 
@@ -43,7 +43,7 @@ class PostStatus(Base):
         DateTime,
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
-        onupdate=datetime.utcnow,
+        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
     )
 
 
@@ -57,5 +57,5 @@ class PostPreview(Base):
         DateTime,
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
-        onupdate=datetime.utcnow,
+        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import create_engine
 
@@ -20,7 +20,7 @@ def test_updated_at_refreshes(tmp_path, monkeypatch):
 
     monkeypatch.setattr("auto.db.get_engine", lambda: engine)
 
-    earlier = datetime.utcnow() - timedelta(days=1)
+    earlier = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1)
 
     with SessionLocal() as session:
         post = Post(
@@ -33,7 +33,7 @@ def test_updated_at_refreshes(tmp_path, monkeypatch):
         status = PostStatus(
             post_id="1",
             network="mastodon",
-            scheduled_at=datetime.utcnow(),
+            scheduled_at=datetime.now(timezone.utc).replace(tzinfo=None),
             updated_at=earlier,
         )
         preview = PostPreview(


### PR DESCRIPTION
## Summary
- avoid `datetime.utcnow()` deprecation warnings by using timezone-aware `datetime.now(timezone.utc)`
- adjust model column callbacks and tests accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877d145da6c832a87b8e1f8f0f6cbe6