### PR TITLE
Remove redundant sys.path tweaks in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,10 @@ import sys
 from sqlalchemy import create_engine
 import pytest
 
-SRC = Path(__file__).resolve().parents[1] / "src"
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
 sys.path.insert(0, str(SRC))
+sys.path.insert(0, str(ROOT))
 
 from auto.feeds.ingestion import init_db
 from auto.db import SessionLocal

--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -1,10 +1,8 @@
 import sqlite3
-import sys
 from pathlib import Path
 from fastapi.testclient import TestClient
 from bs4 import BeautifulSoup
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import auto.main as main
 from sqlalchemy import create_engine

--- a/tests/test_feed_parsing.py
+++ b/tests/test_feed_parsing.py
@@ -1,8 +1,5 @@
-import sys
 from pathlib import Path
 from types import SimpleNamespace
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from bs4 import BeautifulSoup
 from dateutil import parser

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,8 +1,4 @@
 import sqlite3
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from sqlalchemy import create_engine
 from auto.feeds.ingestion import init_db, save_entries

--- a/tests/test_medium_client.py
+++ b/tests/test_medium_client.py
@@ -1,8 +1,3 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-
 from auto.automation.medium import MediumClient
 
 

--- a/tests/test_medium_login_integration.py
+++ b/tests/test_medium_login_integration.py
@@ -1,11 +1,6 @@
 import os
-import sys
-from pathlib import Path
 import pytest
 from selenium import webdriver
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-
 from auto.automation.medium import MediumClient  # noqa: E402
 
 

--- a/tests/test_medium_magic_link.py
+++ b/tests/test_medium_magic_link.py
@@ -1,10 +1,3 @@
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "src"))
-sys.path.insert(0, str(ROOT))
-
 import tasks  # noqa: E402
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,4 @@
-import sys
-from pathlib import Path
 from datetime import datetime, timedelta, timezone
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from auto.db import SessionLocal
 from auto.models import Post, PostStatus, PostPreview

--- a/tests/test_quick_post.py
+++ b/tests/test_quick_post.py
@@ -1,11 +1,5 @@
-import sys
 from datetime import datetime
-from pathlib import Path
 from invoke import Context
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "src"))
-sys.path.insert(0, str(ROOT))
 
 import tasks  # noqa: E402
 from auto.db import SessionLocal  # noqa: E402

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,9 +1,5 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
-import sys
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from auto.db import SessionLocal
 from auto.models import Post, PostStatus, PostPreview

--- a/tests/test_trending_tags.py
+++ b/tests/test_trending_tags.py
@@ -1,10 +1,4 @@
-import sys
-from pathlib import Path
 from invoke import Context
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "src"))
-sys.path.insert(0, str(ROOT))
 
 import tasks  # noqa: E402
 import mastodon  # noqa: E402


### PR DESCRIPTION
## Summary
- rely on shared sys.path handling in `conftest`
- drop per-test additions of the project paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ddc74170832a9cecbb138f1b8699