### PR TITLE
Fix schedule timezone bug

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,10 +17,6 @@
 - ``DummyResponse`` classes for mocking ``requests.get`` appear in multiple test files. Factor them into a common helper.
 
 ## BUGS
-- ``schedule`` allows timezone‑aware datetimes for relative values, but the
-  scheduler compares naive UTC timestamps.  Persisting aware values may silently
-  drop timezone information and lead to inconsistent schedules.
-  【F:tasks.py†L75-L87】【F:src/auto/scheduler.py†L71-L74】
 - ``schedule`` does not verify that the post ID exists before inserting a
   ``PostStatus`` record.  An invalid ID triggers a database integrity error
   instead of a clear message. 【F:tasks.py†L92-L105】
@@ -33,4 +29,3 @@
 - Standardize timezone handling with aware datetime objects throughout the app.
 - Consider asynchronous HTTP clients for feed ingestion and posting to improve throughput.
 - Package the project so tests no longer modify `sys.path` directly.
-

--- a/tasks.py
+++ b/tasks.py
@@ -87,6 +87,8 @@ def schedule(ctx, post_id, time, network=None):
         return parser.isoparse(value)
 
     scheduled_at = _parse_when(time)
+    if scheduled_at.tzinfo is not None:
+        scheduled_at = scheduled_at.astimezone(timezone.utc).replace(tzinfo=None)
     networks = [network] if network else ["mastodon"]
 
     with SessionLocal() as session:


### PR DESCRIPTION
## Summary
- ensure `schedule` stores times as naive UTC
- update TODO list

## Testing
- `pre-commit run --files tasks.py TODO.md`

------
https://chatgpt.com/codex/tasks/task_e_6877ea1729b0832a9dac9c7580f99859