### PR TITLE
Fix DRY in tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,6 @@
 ## Code Smells
 
 ## DRY
-- ``DummyResponse`` classes for mocking ``requests.get`` appear in multiple test files. Factor them into a common helper.
 
 ## BUGS
 - ``schedule`` allows timezone‑aware datetimes for relative values, but the

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,10 @@
+class DummyResponse:
+    """Simple mock response for requests.get."""
+
+    def __init__(self, content=b"<rss></rss>", status_code=200):
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        """Pretend to raise for HTTP errors."""
+        pass

--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -2,6 +2,7 @@ import sqlite3
 from pathlib import Path
 from fastapi.testclient import TestClient
 from bs4 import BeautifulSoup
+from tests.helpers import DummyResponse
 
 
 import auto.main as main
@@ -54,14 +55,6 @@ def test_run_ingest_uses_env_variable(monkeypatch):
     import auto.main as main_module
 
     called = {}
-
-    class DummyResponse:
-        def __init__(self):
-            self.content = b"<rss></rss>"
-            self.status_code = 200
-
-        def raise_for_status(self):
-            pass
 
     def fake_get(url, timeout=10):
         called["url"] = url

--- a/tests/test_feed_parsing.py
+++ b/tests/test_feed_parsing.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from bs4 import BeautifulSoup
 from dateutil import parser
 from auto.feeds.ingestion import _parse_entry, fetch_feed
+from tests.helpers import DummyResponse
 
 
 def test_parse_entry_from_soup():
@@ -53,14 +54,6 @@ def test_parse_entry_from_dummy_object():
 def test_fetch_feed_returns_items(monkeypatch):
     sample_xml = Path(__file__).with_name("sample_feed.xml").read_bytes()
 
-    class DummyResponse:
-        def __init__(self, content):
-            self.content = content
-            self.status_code = 200
-
-        def raise_for_status(self):
-            pass
-
     def fake_get(url, timeout=10):
         return DummyResponse(sample_xml)
 
@@ -76,14 +69,6 @@ def test_fetch_feed_uses_env_variable(monkeypatch):
     monkeypatch.setenv("SUBSTACK_FEED_URL", "http://env.example/feed")
 
     called = {}
-
-    class DummyResponse:
-        def __init__(self):
-            self.content = b"<rss></rss>"
-            self.status_code = 200
-
-        def raise_for_status(self):
-            pass
 
     def fake_get(url, timeout=10):
         called["url"] = url


### PR DESCRIPTION
## Summary
- extract `DummyResponse` into shared test helper
- update tests to use the helper
- remove DRY item from TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ea41472c832aacf9a4c9b57475d7