### PR TITLE
Add scheduled ingestion service

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,9 @@
 # RSS feed to ingest; defaults to geoffreyducharme if unset
 SUBSTACK_FEED_URL=https://example.substack.com/feed
 
+# Seconds between automatic feed ingestions
+INGEST_INTERVAL=600
+
 # Database connection string
 # SQLite is used by default
 DATABASE_URL=sqlite:///./substack.db

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The following variables are used:
 - `MAX_ATTEMPTS` – maximum number of publish attempts before giving up.
 - `SCHEDULER_POLL_INTERVAL` – seconds between scheduler iterations,
   default `5`.
+- `INGEST_INTERVAL` – seconds between automatic feed ingestions,
+  default `600`.
 - `POST_DELAY` – pause after each publish attempt, default `1` second.
 - `LOG_LEVEL` – log verbosity used by `configure_logging()`, default `INFO`.
 
@@ -56,13 +58,15 @@ python -m auto.scheduler
 
 ## Ingesting Substack posts
 
-Once the server is running you can trigger an ingestion job:
+The application automatically ingests the configured RSS feed on a
+schedule controlled by `INGEST_INTERVAL`. You can also trigger a run
+manually:
 
 ```bash
 invoke ingest
 ```
 
-This fetches the configured Substack RSS feed and saves any new posts into the
+Both methods fetch the configured RSS feed and store any new posts in the
 database.
 
 ## Posting to social networks

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## High Priority
 
 ## Medium Priority
-- Implement periodic/scheduled ingestion instead of manual triggering.
 - Expose Prometheus metrics for published and failed posts to aid health
   monitoring.
 

--- a/src/auto/config.py
+++ b/src/auto/config.py
@@ -42,6 +42,12 @@ def get_poll_interval() -> int:
     return int(os.getenv("SCHEDULER_POLL_INTERVAL", "5"))
 
 
+def get_ingest_interval() -> int:
+    """Return the delay in seconds between automatic feed ingestions."""
+    load_env()
+    return int(os.getenv("INGEST_INTERVAL", "600"))
+
+
 def get_post_delay() -> float:
     load_env()
     return float(os.getenv("POST_DELAY", "1"))

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -150,6 +150,15 @@ def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
                     logger.error("Failed to save post %s: %s", title, exc)
 
 
+def run_ingest():
+    """Fetch the configured feed and store any new entries."""
+    try:
+        items = fetch_feed()
+        save_entries(items)
+    except Exception as exc:
+        logger.error("Ingestion failed: %s", exc)
+
+
 def main():
     init_db()
     items = fetch_feed()

--- a/src/auto/ingest_scheduler.py
+++ b/src/auto/ingest_scheduler.py
@@ -1,0 +1,50 @@
+import asyncio
+import logging
+from typing import Optional
+
+from .main import run_ingest
+from .config import get_ingest_interval
+
+logger = logging.getLogger(__name__)
+
+
+async def _ingest_loop():
+    while True:
+        try:
+            await asyncio.to_thread(run_ingest)
+        except Exception as exc:
+            logger.error("Scheduled ingestion failed: %s", exc)
+        await asyncio.sleep(get_ingest_interval())
+
+
+class IngestScheduler:
+    """Run feed ingestion on a timer in the background."""
+
+    def __init__(self) -> None:
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> Optional[asyncio.Task]:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(_ingest_loop())
+        return self._task
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+
+# backward compatible default instance
+default_scheduler = IngestScheduler()
+
+
+async def start() -> Optional[asyncio.Task]:
+    return await default_scheduler.start()
+
+
+async def stop() -> None:
+    await default_scheduler.stop()

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -1,8 +1,9 @@
 # main.py
 from fastapi import FastAPI, BackgroundTasks
 from contextlib import asynccontextmanager
-from .feeds.ingestion import init_db, fetch_feed, save_entries
+from .feeds.ingestion import init_db, run_ingest
 from . import scheduler, configure_logging
+from . import ingest_scheduler
 import logging
 
 logger = logging.getLogger(__name__)
@@ -13,10 +14,12 @@ async def lifespan(app: FastAPI):
     configure_logging()
     init_db()
     await scheduler.start()
+    await ingest_scheduler.start()
     try:
         yield
     finally:
         await scheduler.stop()
+        await ingest_scheduler.stop()
 
 
 app = FastAPI(lifespan=lifespan)
@@ -27,11 +30,3 @@ async def ingest(background_tasks: BackgroundTasks):
     logger.info("Ingestion requested")
     background_tasks.add_task(run_ingest)
     return {"status": "ingestion queued"}
-
-
-def run_ingest():
-    try:
-        items = fetch_feed()
-        save_entries(items)
-    except Exception as exc:
-        logger.error("Ingestion failed: %s", exc)

--- a/tests/test_api_ingest.py
+++ b/tests/test_api_ingest.py
@@ -14,7 +14,6 @@ def test_ingest_endpoint(tmp_path, monkeypatch):
     parsed = BeautifulSoup(sample_xml, "xml").find_all("item")
 
     monkeypatch.setattr(ingestion, "fetch_feed", lambda url=None: parsed)
-    monkeypatch.setattr(main, "fetch_feed", lambda url=None: parsed)
 
     db_path = tmp_path / "test.db"
     engine = create_engine(
@@ -32,7 +31,6 @@ def test_ingest_endpoint(tmp_path, monkeypatch):
 
     monkeypatch.setattr(ingestion, "init_db", init_db_patch)
     monkeypatch.setattr(ingestion, "save_entries", save_entries_patch)
-    monkeypatch.setattr(main, "save_entries", save_entries_patch)
     monkeypatch.setattr(main, "init_db", init_db_patch)
 
     with TestClient(main.app) as client:
@@ -51,7 +49,7 @@ def test_run_ingest_uses_env_variable(monkeypatch):
     """run_ingest() should fetch the URL from SUBSTACK_FEED_URL."""
     monkeypatch.setenv("SUBSTACK_FEED_URL", "http://env.example/feed")
 
-    import auto.main as main_module
+    import auto.feeds.ingestion as ingest_module
 
     called = {}
 
@@ -68,7 +66,7 @@ def test_run_ingest_uses_env_variable(monkeypatch):
         return DummyResponse()
 
     monkeypatch.setattr("auto.feeds.ingestion.requests.get", fake_get)
-    monkeypatch.setattr(main_module, "save_entries", lambda items: None)
+    monkeypatch.setattr(ingest_module, "save_entries", lambda items: None)
 
-    main_module.run_ingest()
+    ingest_module.run_ingest()
     assert called.get("url") == "http://env.example/feed"

--- a/tests/test_ingest_scheduler.py
+++ b/tests/test_ingest_scheduler.py
@@ -1,0 +1,24 @@
+import asyncio
+
+import auto.ingest_scheduler as ingest_scheduler
+import auto.main as main
+
+
+def test_ingest_scheduler_runs(monkeypatch):
+    called = {"count": 0}
+
+    def fake_run_ingest():
+        called["count"] += 1
+
+    monkeypatch.setattr(ingest_scheduler, "run_ingest", fake_run_ingest)
+    monkeypatch.setenv("INGEST_INTERVAL", "0")
+
+    scheduler = ingest_scheduler.IngestScheduler()
+
+    async def run_loop():
+        await scheduler.start()
+        await asyncio.sleep(0.01)
+        await scheduler.stop()
+
+    asyncio.run(run_loop())
+    assert called["count"] >= 1


### PR DESCRIPTION
## Summary
- implement background ingestion scheduler
- add INGEST_INTERVAL config option
- start ingestion scheduler in FastAPI lifespan
- update docs and sample env file
- remove completed TODO item
- test the ingestion scheduler

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ea818488832aa0da27eb54e24629