### PR TITLE
Fix scheduling bug

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,9 +15,6 @@
 ## DRY
 
 ## BUGS
-- ``schedule`` does not verify that the post ID exists before inserting a
-  ``PostStatus`` record.  An invalid ID triggers a database integrity error
-  instead of a clear message. 【F:tasks.py†L92-L105】
 - The ``/ingest`` endpoint always returns success even if ``run_ingest`` fails
   to fetch or parse the feed, hiding ingestion errors from the caller.
   【F:src/auto/main.py†L27-L39】

--- a/tasks.py
+++ b/tasks.py
@@ -70,7 +70,7 @@ def schedule(ctx, post_id, time, network=None):
     from datetime import datetime, timedelta, timezone
     from dateutil import parser
     from auto.db import SessionLocal
-    from auto.models import PostStatus
+    from auto.models import Post, PostStatus
 
     def _parse_when(value: str) -> datetime:
         value = value.strip().lower()
@@ -92,6 +92,9 @@ def schedule(ctx, post_id, time, network=None):
     networks = [network] if network else ["mastodon"]
 
     with SessionLocal() as session:
+        if session.get(Post, post_id) is None:
+            print(f"Post {post_id} not found")
+            return
         for net in networks:
             ps = session.get(PostStatus, {"post_id": post_id, "network": net})
             if ps is None:

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,17 @@
+from invoke import Context
+
+import tasks  # noqa: E402
+from auto.db import SessionLocal  # noqa: E402
+from auto.models import PostStatus
+
+
+def test_schedule_missing_post(monkeypatch, test_db_engine, capsys):
+    tasks.schedule(Context(), post_id="missing", time="in 1s")
+
+    captured = capsys.readouterr()
+    assert "Post missing not found" in captured.out
+
+    with SessionLocal() as session:
+        statuses = session.query(PostStatus).all()
+        assert statuses == []
+


### PR DESCRIPTION
## Summary
- validate post IDs in `schedule` before inserting `PostStatus`
- note bug fix in TODO list
- test scheduling with an invalid post

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f11c1fac832aa79af37cf557c343