### PR TITLE
Add delay after text entry in Safari helper

### DIFF
--- a/scripts/safari_fill.scpt
+++ b/scripts/safari_fill.scpt
@@ -34,6 +34,7 @@ on run argv
             "if(!promptDiv){console.error('⚠️ No element found with id prompt-textarea');return;}" & ¬
             "promptDiv.textContent=text;" & ¬
             "promptDiv.dispatchEvent(new Event('input'));" & ¬
+            "setTimeout(()=>{" & ¬
             "console.log('📥 prompt-textarea now contains:',promptDiv.textContent);" & ¬
             "const candidates=document.querySelectorAll('div.flex.items-center.justify-center');" & ¬
             "console.log('🔍 Found',candidates.length,'candidates:',candidates);" & ¬
@@ -46,7 +47,8 @@ on run argv
             "console.log('✅ Clicked the Code button!');" & ¬
             "}else{" & ¬
             "console.warn('❌ No matching Code button found—check the debug log above.');" & ¬
-            "}}"
+            "},500);" & ¬
+            "}"
         set js to jsFunction & " setPromptAndClickCode('" & textValue & "'); 'OK';"
         set resultText to do JavaScript js in current tab of window 1
         return resultText


### PR DESCRIPTION
## Summary
- update `safari_fill` script to wait 0.5s after setting the prompt text

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f1599554832a852e26fe5efbc3ba