### PR TITLE
Refactor helper functions for Invoke tasks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,9 @@
 # tasks.py
+import os
 from invoke import task
+
+__path__ = [os.path.join(os.path.dirname(__file__), "tasks")]
+from tasks.helpers import _get_medium_magic_link, _fill_safari_tab, _parse_when
 
 
 @task
@@ -66,25 +70,9 @@ def schedule(ctx, post_id, time, network=None):
     ``"in 1h"`` or ``"+30m"``. If ``--network`` is omitted the post is
     scheduled for all known networks.
     """
-    import re
-    from datetime import datetime, timedelta, timezone
-    from dateutil import parser
+    from datetime import timezone
     from auto.db import SessionLocal
     from auto.models import PostStatus
-
-    def _parse_when(value: str) -> datetime:
-        value = value.strip().lower()
-        m = re.match(r"(?:in\s+|\+)?(\d+)([smhd])$", value)
-        if m:
-            amount, unit = m.groups()
-            delta = {
-                "s": timedelta(seconds=int(amount)),
-                "m": timedelta(minutes=int(amount)),
-                "h": timedelta(hours=int(amount)),
-                "d": timedelta(days=int(amount)),
-            }[unit]
-            return datetime.now(timezone.utc) + delta
-        return parser.isoparse(value)
 
     scheduled_at = _parse_when(time)
     if scheduled_at.tzinfo is not None:
@@ -188,21 +176,6 @@ def chat(
     print(response)
 
 
-def _get_medium_magic_link():
-    """Return the latest Medium magic link via Apple Mail if present."""
-    import subprocess
-    import re
-    from pathlib import Path
-
-    script = Path(__file__).resolve().parent / "scripts" / "fetch_medium_link.scpt"
-    result = subprocess.run(["osascript", str(script)], capture_output=True, text=True)
-    if result.returncode != 0:
-        raise RuntimeError(result.stderr)
-
-    match = re.search(r"https://medium\.com/(?:m/[^\s]+|magic/\S+)", result.stdout)
-    return match.group(0) if match else None
-
-
 @task
 def medium_magic_link(ctx):
     """Check Apple Mail once for a Medium magic link and print the result."""
@@ -212,25 +185,6 @@ def medium_magic_link(ctx):
         print(f"Found magic link: {link}")
     else:
         print("Magic link not found")
-
-
-def _fill_safari_tab(url: str, selector: str, text: str) -> str:
-    """Open Safari to ``url`` and fill ``selector`` with ``text``.
-
-    Returns the JavaScript status string from the AppleScript.
-    """
-    import subprocess
-    from pathlib import Path
-
-    script = Path(__file__).resolve().parent / "scripts" / "safari_fill.scpt"
-    result = subprocess.run(
-        ["osascript", str(script), url, selector, text],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(result.stderr)
-    return result.stdout.strip()
 
 
 @task

--- a/tasks/helpers.py
+++ b/tasks/helpers.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from dateutil import parser
+
+
+def _parse_when(value: str) -> datetime:
+    """Parse relative or absolute time specifications."""
+    value = value.strip().lower()
+    m = re.match(r"(?:in\s+|\+)?(\d+)([smhd])$", value)
+    if m:
+        amount, unit = m.groups()
+        delta = {
+            "s": timedelta(seconds=int(amount)),
+            "m": timedelta(minutes=int(amount)),
+            "h": timedelta(hours=int(amount)),
+            "d": timedelta(days=int(amount)),
+        }[unit]
+        return datetime.now(timezone.utc) + delta
+    return parser.isoparse(value)
+
+
+def _get_medium_magic_link() -> str | None:
+    """Return the latest Medium magic link via Apple Mail if present."""
+    script = Path(__file__).resolve().parents[1] / "scripts" / "fetch_medium_link.scpt"
+    result = subprocess.run(["osascript", str(script)], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    match = re.search(r"https://medium\.com/(?:m/[^\s]+|magic/\S+)", result.stdout)
+    return match.group(0) if match else None
+
+
+def _fill_safari_tab(url: str, selector: str, text: str) -> str:
+    """Open Safari to ``url`` and fill ``selector`` with ``text``."""
+    script = Path(__file__).resolve().parents[1] / "scripts" / "safari_fill.scpt"
+    result = subprocess.run(
+        ["osascript", str(script), url, selector, text],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return result.stdout.strip()


### PR DESCRIPTION
## Summary
- move helper functions out of `tasks.py`
- expose helper tasks via `tasks/helpers.py`
- adjust `tasks.py` to load from new module and treat itself as a package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f212d2b4832abc1e378f65b189fa