### PR TITLE
Fix timezone handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## High Priority
 
 ## Medium Priority
-- Standardize timezone handling with aware datetime objects throughout the app.
 - Consider asynchronous HTTP clients for feed ingestion and posting to improve throughput.
 - Expose Prometheus metrics for published and failed posts to aid health
   monitoring.

--- a/src/auto/models.py
+++ b/src/auto/models.py
@@ -14,15 +14,15 @@ class Post(Base):
     summary = Column(Text)
     published = Column(String)
     created_at = Column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
     )
     updated_at = Column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
-        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
 
 
@@ -32,7 +32,7 @@ class PostStatus(Base):
     post_id = Column(String, ForeignKey("posts.id"), primary_key=True)
     network = Column(String, primary_key=True)
     scheduled_at = Column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
     )
@@ -40,10 +40,10 @@ class PostStatus(Base):
     attempts = Column(Integer, nullable=False, server_default="0")
     last_error = Column(Text)
     updated_at = Column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
-        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        onupdate=lambda: datetime.now(timezone.utc),
     )
 
 
@@ -54,8 +54,8 @@ class PostPreview(Base):
     network = Column(String, primary_key=True)
     content = Column(Text, nullable=False)
     updated_at = Column(
-        DateTime,
+        DateTime(timezone=True),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
-        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        onupdate=lambda: datetime.now(timezone.utc),
     )

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -56,8 +56,8 @@ async def _publish(status: PostStatus, session):
 
 
 async def process_pending(max_attempts: Optional[int] = None):
-    # use timezone-aware UTC datetime then drop tz info for DB comparison
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    # use timezone-aware UTC datetime for all comparisons
+    now = datetime.now(timezone.utc)
     if max_attempts is None:
         max_attempts = get_max_attempts()
     with SessionLocal() as session:

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,7 @@ def schedule(ctx, post_id, time, network=None):
 
     scheduled_at = _parse_when(time)
     if scheduled_at.tzinfo is not None:
-        scheduled_at = scheduled_at.astimezone(timezone.utc).replace(tzinfo=None)
+        scheduled_at = scheduled_at.astimezone(timezone.utc)
     networks = [network] if network else ["mastodon"]
 
     with SessionLocal() as session:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ from auto.models import Post, PostStatus, PostPreview
 
 def test_updated_at_refreshes(test_db_engine):
 
-    earlier = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1)
+    earlier = datetime.now(timezone.utc) - timedelta(days=1)
 
     with SessionLocal() as session:
         post = Post(
@@ -19,7 +19,7 @@ def test_updated_at_refreshes(test_db_engine):
         status = PostStatus(
             post_id="1",
             network="mastodon",
-            scheduled_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            scheduled_at=datetime.now(timezone.utc),
             updated_at=earlier,
         )
         preview = PostPreview(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -26,8 +26,7 @@ def test_process_pending_publishes(test_db_engine, monkeypatch):
         status = PostStatus(
             post_id="1",
             network="mastodon",
-            scheduled_at=datetime.now(timezone.utc).replace(tzinfo=None)
-            - timedelta(seconds=1),
+            scheduled_at=datetime.now(timezone.utc) - timedelta(seconds=1),
         )
         session.add(status)
         session.commit()
@@ -61,8 +60,7 @@ def test_process_pending_retries_error(test_db_engine, monkeypatch):
             network="mastodon",
             status="error",
             attempts=1,
-            scheduled_at=datetime.now(timezone.utc).replace(tzinfo=None)
-            - timedelta(seconds=1),
+            scheduled_at=datetime.now(timezone.utc) - timedelta(seconds=1),
         )
         session.add(status)
         session.commit()
@@ -97,8 +95,7 @@ def test_process_pending_ignores_exceeded_attempts(test_db_engine, monkeypatch):
             network="mastodon",
             status="error",
             attempts=3,
-            scheduled_at=datetime.now(timezone.utc).replace(tzinfo=None)
-            - timedelta(seconds=1),
+            scheduled_at=datetime.now(timezone.utc) - timedelta(seconds=1),
         )
         session.add(status)
         session.commit()
@@ -132,8 +129,7 @@ def test_process_pending_uses_preview(test_db_engine, monkeypatch):
         status = PostStatus(
             post_id="1",
             network="mastodon",
-            scheduled_at=datetime.now(timezone.utc).replace(tzinfo=None)
-            - timedelta(seconds=1),
+            scheduled_at=datetime.now(timezone.utc) - timedelta(seconds=1),
         )
         preview = PostPreview(
             post_id="1", network="mastodon", content="Look {{ post.title }} {{ post.link }}"


### PR DESCRIPTION
## Summary
- store timezone aware datetimes in the DB models
- adjust scheduler comparisons to keep tzinfo
- preserve timezone information when scheduling posts
- update related tests
- trim TODO item for timezone cleanup

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f67ea7f8832aa13a6de5496878ba