### PR TITLE
Implement async HTTP clients

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## High Priority
 
 ## Medium Priority
-- Consider asynchronous HTTP clients for feed ingestion and posting to improve throughput.
 - Expose Prometheus metrics for published and failed posts to aid health
   monitoring.
 

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -1,6 +1,8 @@
+import asyncio
 import logging
-import requests
 from typing import Optional
+
+import httpx
 from bs4 import BeautifulSoup
 from alembic.config import Config
 from alembic import command
@@ -64,18 +66,24 @@ def init_db(db_path=DB_PATH, *, engine=None, session_factory=None):
         raise
 
 
-def fetch_feed(feed_url: Optional[str] = None):
-    """Fetch and parse the RSS feed using BeautifulSoup."""
+async def fetch_feed_async(feed_url: Optional[str] = None):
+    """Fetch and parse the RSS feed asynchronously."""
     if feed_url is None:
         feed_url = get_feed_url()
     try:
-        response = requests.get(feed_url, timeout=10)
-        response.raise_for_status()
-    except requests.RequestException as exc:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.get(feed_url)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
         logger.error("Failed to fetch feed %s: %s", feed_url, exc)
         raise
     soup = BeautifulSoup(response.content, "xml")
     return soup.find_all("item")
+
+
+def fetch_feed(feed_url: Optional[str] = None):
+    """Synchronous wrapper around :func:`fetch_feed_async`."""
+    return asyncio.run(fetch_feed_async(feed_url))
 
 
 def _extract_text(item, name: str, default: str = ""):
@@ -150,19 +158,23 @@ def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
                     logger.error("Failed to save post %s: %s", title, exc)
 
 
-def run_ingest():
-    """Fetch the configured feed and store any new entries."""
+async def run_ingest_async() -> None:
+    """Fetch the configured feed and store any new entries asynchronously."""
     try:
-        items = fetch_feed()
+        items = await fetch_feed_async()
         save_entries(items)
     except Exception as exc:
         logger.error("Ingestion failed: %s", exc)
 
 
+def run_ingest() -> None:
+    """Synchronous wrapper around :func:`run_ingest_async`."""
+    asyncio.run(run_ingest_async())
+
+
 def main():
     init_db()
-    items = fetch_feed()
-    save_entries(items)
+    asyncio.run(run_ingest_async())
 
 
 if __name__ == "__main__":

--- a/src/auto/ingest_scheduler.py
+++ b/src/auto/ingest_scheduler.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import Optional
 
-from .main import run_ingest
+from .feeds.ingestion import run_ingest_async
 from .config import get_ingest_interval
 
 logger = logging.getLogger(__name__)
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 async def _ingest_loop():
     while True:
         try:
-            await asyncio.to_thread(run_ingest)
+            await run_ingest_async()
         except Exception as exc:
             logger.error("Scheduled ingestion failed: %s", exc)
         await asyncio.sleep(get_ingest_interval())

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -9,7 +9,7 @@ from sqlalchemy import and_, or_
 
 from .db import SessionLocal, get_engine
 from .models import PostStatus, Post, PostPreview
-from .socials.mastodon_client import post_to_mastodon
+from .socials.mastodon_client import post_to_mastodon_async
 from .config import get_poll_interval, get_post_delay, get_max_attempts
 
 logger = logging.getLogger(__name__)
@@ -36,11 +36,7 @@ async def _publish(status: PostStatus, session):
                 text = Template(preview.content).render(post=post)
             else:
                 text = f"{post.title} {post.link}"
-            await asyncio.to_thread(
-                post_to_mastodon,
-                text,
-                visibility="unlisted",
-            )
+            await post_to_mastodon_async(text, visibility="unlisted")
         else:
             raise ValueError(f"Unsupported network {status.network}")
         status.status = "published"

--- a/src/auto/socials/mastodon_client.py
+++ b/src/auto/socials/mastodon_client.py
@@ -1,26 +1,35 @@
-from mastodon import Mastodon
+import asyncio
 import logging
+from mastodon import Mastodon
+import httpx
 
 from ..config import get_mastodon_instance, get_mastodon_token
 
 logger = logging.getLogger(__name__)
 
 
-def post_to_mastodon(status: str, visibility: str = "private") -> None:
-    """Post a status to Mastodon."""
+async def post_to_mastodon_async(status: str, visibility: str = "private") -> None:
+    """Post a status to Mastodon asynchronously."""
+    token = get_mastodon_token()
+    instance = get_mastodon_instance()
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
     try:
-        masto = Mastodon(
-            access_token=get_mastodon_token(),
-            api_base_url=get_mastodon_instance(),
-        )
-        # `toot` in Mastodon.py 2.x does not accept extra keyword arguments such as
-        # ``visibility``.  Use ``status_post`` instead, which exposes these
-        # parameters.
-        masto.status_post(status=status, visibility=visibility)
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(
+                f"{instance}/api/v1/statuses",
+                data={"status": status, "visibility": visibility},
+                headers=headers,
+            )
+            resp.raise_for_status()
         logger.info("Posted to Mastodon")
     except Exception as exc:
         logger.error("Failed to post to Mastodon: %s", exc)
         raise
+
+
+def post_to_mastodon(status: str, visibility: str = "private") -> None:
+    """Synchronous wrapper for :func:`post_to_mastodon_async`."""
+    asyncio.run(post_to_mastodon_async(status=status, visibility=visibility))
 
 
 if __name__ == "__main__":

--- a/tests/test_feed_parsing.py
+++ b/tests/test_feed_parsing.py
@@ -54,10 +54,10 @@ def test_parse_entry_from_dummy_object():
 def test_fetch_feed_returns_items(monkeypatch):
     sample_xml = Path(__file__).with_name("sample_feed.xml").read_bytes()
 
-    def fake_get(url, timeout=10):
+    async def fake_get(self, url):
         return DummyResponse(sample_xml)
 
-    monkeypatch.setattr("requests.get", fake_get)
+    monkeypatch.setattr("auto.feeds.ingestion.httpx.AsyncClient.get", fake_get)
 
     items = fetch_feed("http://example.com/feed")
     assert isinstance(items, list)
@@ -70,11 +70,11 @@ def test_fetch_feed_uses_env_variable(monkeypatch):
 
     called = {}
 
-    def fake_get(url, timeout=10):
+    async def fake_get(self, url):
         called["url"] = url
         return DummyResponse()
 
-    monkeypatch.setattr("auto.feeds.ingestion.requests.get", fake_get)
+    monkeypatch.setattr("auto.feeds.ingestion.httpx.AsyncClient.get", fake_get)
 
     from auto.feeds import ingestion as ingestion_module
 

--- a/tests/test_ingest_scheduler.py
+++ b/tests/test_ingest_scheduler.py
@@ -7,10 +7,10 @@ import auto.main as main
 def test_ingest_scheduler_runs(monkeypatch):
     called = {"count": 0}
 
-    def fake_run_ingest():
+    async def fake_run_ingest():
         called["count"] += 1
 
-    monkeypatch.setattr(ingest_scheduler, "run_ingest", fake_run_ingest)
+    monkeypatch.setattr(ingest_scheduler, "run_ingest_async", fake_run_ingest)
     monkeypatch.setenv("INGEST_INTERVAL", "0")
 
     scheduler = ingest_scheduler.IngestScheduler()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -31,9 +31,12 @@ def test_process_pending_publishes(test_db_engine, monkeypatch):
         session.add(status)
         session.commit()
 
+    async def fake_post(text, visibility="unlisted"):
+        DummyPoster.post(text)
+
     monkeypatch.setattr(
-        "auto.scheduler.post_to_mastodon",
-        lambda text, visibility="unlisted": DummyPoster.post(text),
+        "auto.scheduler.post_to_mastodon_async",
+        fake_post,
     )
 
     monkeypatch.setenv("POST_DELAY", "0")
@@ -65,9 +68,12 @@ def test_process_pending_retries_error(test_db_engine, monkeypatch):
         session.add(status)
         session.commit()
 
+    async def fake_post(text, visibility="unlisted"):
+        DummyPoster.post(text)
+
     monkeypatch.setattr(
-        "auto.scheduler.post_to_mastodon",
-        lambda text, visibility="unlisted": DummyPoster.post(text),
+        "auto.scheduler.post_to_mastodon_async",
+        fake_post,
     )
 
     monkeypatch.setenv("POST_DELAY", "0")
@@ -100,9 +106,12 @@ def test_process_pending_ignores_exceeded_attempts(test_db_engine, monkeypatch):
         session.add(status)
         session.commit()
 
+    async def fake_post(text, visibility="unlisted"):
+        DummyPoster.post(text)
+
     monkeypatch.setattr(
-        "auto.scheduler.post_to_mastodon",
-        lambda text, visibility="unlisted": DummyPoster.post(text),
+        "auto.scheduler.post_to_mastodon_async",
+        fake_post,
     )
 
     monkeypatch.setenv("POST_DELAY", "0")
@@ -137,11 +146,11 @@ def test_process_pending_uses_preview(test_db_engine, monkeypatch):
         session.add_all([status, preview])
         session.commit()
 
-    def fake_post(text, visibility="unlisted"):
+    async def fake_post(text, visibility="unlisted"):
         captured["text"] = text
         DummyPoster.post(text)
 
-    monkeypatch.setattr("auto.scheduler.post_to_mastodon", fake_post)
+    monkeypatch.setattr("auto.scheduler.post_to_mastodon_async", fake_post)
 
     monkeypatch.setenv("POST_DELAY", "0")
 


### PR DESCRIPTION
## Summary
- adopt httpx for feed ingestion with async helpers
- send Mastodon posts asynchronously via httpx
- update scheduler and ingest scheduler to use async functions
- adjust tests for asynchronous behavior
- remove TODO about async HTTP clients

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f81ebcf0832aa475157cab8b8c79