### PR TITLE
Add Safari automation controller

### DIFF
--- a/scripts/safari_control.scpt
+++ b/scripts/safari_control.scpt
@@ -1,0 +1,64 @@
+on run argv
+    if (count of argv) is 0 then
+        return "usage: safari_control.scpt command [args]"
+    end if
+    set cmd to item 1 of argv
+    if cmd is "open" then
+        if (count of argv) < 2 then return "missing url"
+        set targetUrl to item 2 of argv
+        tell application "Safari"
+            activate
+            set foundTab to false
+            repeat with w in every window
+                repeat with t in every tab of w
+                    if (URL of t) is targetUrl then
+                        set current tab of w to t
+                        set index of w to 1
+                        set foundTab to true
+                        exit repeat
+                    end if
+                end repeat
+                if foundTab then exit repeat
+            end repeat
+            if not foundTab then
+                if (count of windows) is 0 then
+                    make new document
+                end if
+                set newTab to make new tab at end of tabs of window 1
+                set URL of newTab to targetUrl
+                set current tab of window 1 to newTab
+            end if
+            return "OK"
+        end tell
+    else if cmd is "click" then
+        if (count of argv) < 2 then return "missing selector"
+        set theSelector to item 2 of argv
+        tell application "Safari"
+            do JavaScript "var el=document.querySelector('" & theSelector & "'); if(el){el.click();}" in current tab of window 1
+            return "OK"
+        end tell
+    else if cmd is "fill" then
+        if (count of argv) < 3 then return "missing args"
+        set theSelector to item 2 of argv
+        set valueStr to item 3 of argv
+        tell application "Safari"
+            do JavaScript "var el=document.querySelector('" & theSelector & "'); if(el){el.value='" & valueStr & "'; el.dispatchEvent(new Event('input'));}" in current tab of window 1
+            return "OK"
+        end tell
+    else if cmd is "run_js" then
+        if (count of argv) < 2 then return "missing js"
+        set jsCode to item 2 of argv
+        tell application "Safari"
+            return do JavaScript jsCode in current tab of window 1
+        end tell
+    else if cmd is "close_tab" then
+        tell application "Safari"
+            if (count of windows) > 0 then
+                close current tab of window 1
+            end if
+            return "OK"
+        end tell
+    else
+        return "unknown command"
+    end if
+end run

--- a/src/auto/automation/safari.py
+++ b/src/auto/automation/safari.py
@@ -1,0 +1,43 @@
+import subprocess
+from pathlib import Path
+
+
+class SafariController:
+    """Control Safari using AppleScript commands."""
+
+    def __init__(self, script: Path | None = None) -> None:
+        if script is None:
+            script = (
+                Path(__file__).resolve().parents[3] / "scripts" / "safari_control.scpt"
+            )
+        self.script = script
+
+    def _run(self, command: str, *args: str) -> str:
+        result = subprocess.run(
+            ["osascript", str(self.script), command, *args],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr)
+        return result.stdout.strip()
+
+    def open(self, url: str) -> str:
+        """Open ``url`` in Safari, activating an existing tab if present."""
+        return self._run("open", url)
+
+    def click(self, selector: str) -> str:
+        """Click the element matching ``selector``."""
+        return self._run("click", selector)
+
+    def fill(self, selector: str, text: str) -> str:
+        """Fill ``selector`` with ``text``."""
+        return self._run("fill", selector, text)
+
+    def run_js(self, code: str) -> str:
+        """Execute JavaScript ``code`` in the current tab."""
+        return self._run("run_js", code)
+
+    def close_tab(self) -> str:
+        """Close the current Safari tab."""
+        return self._run("close_tab")

--- a/tasks.py
+++ b/tasks.py
@@ -3,7 +3,8 @@ import os
 from invoke import task
 
 __path__ = [os.path.join(os.path.dirname(__file__), "tasks")]
-from tasks.helpers import _get_medium_magic_link, _fill_safari_tab, _parse_when
+from tasks.helpers import _get_medium_magic_link, _parse_when
+from auto.automation.safari import SafariController
 
 
 @task
@@ -193,7 +194,9 @@ def medium_magic_link(ctx):
 @task
 def safari_fill(ctx, url, selector, text):
     """Open or activate a Safari tab and type text into the given field."""
-    result = _fill_safari_tab(url, selector, text)
+    controller = SafariController()
+    controller.open(url)
+    result = controller.fill(selector, text)
     if result:
         print(result)
 

--- a/tasks/helpers.py
+++ b/tasks/helpers.py
@@ -4,6 +4,8 @@ import re
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from auto.automation.safari import SafariController
 from dateutil import parser
 
 
@@ -35,12 +37,6 @@ def _get_medium_magic_link() -> str | None:
 
 def _fill_safari_tab(url: str, selector: str, text: str) -> str:
     """Open Safari to ``url`` and fill ``selector`` with ``text``."""
-    script = Path(__file__).resolve().parents[1] / "scripts" / "safari_fill.scpt"
-    result = subprocess.run(
-        ["osascript", str(script), url, selector, text],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(result.stderr)
-    return result.stdout.strip()
+    controller = SafariController()
+    controller.open(url)
+    return controller.fill(selector, text)

--- a/tests/test_safari_controller.py
+++ b/tests/test_safari_controller.py
@@ -1,0 +1,61 @@
+from auto.automation.safari import SafariController
+
+
+def _fake_run(calls):
+    def runner(cmd, capture_output=True, text=True):
+        calls.append(cmd)
+        from subprocess import CompletedProcess
+
+        return CompletedProcess(cmd, 0, stdout="OK", stderr="")
+
+    return runner
+
+
+def test_open(monkeypatch):
+    calls = []
+    monkeypatch.setattr("subprocess.run", _fake_run(calls))
+    controller = SafariController()
+    controller.open("https://example.com")
+    expected = [
+        "osascript",
+        str(controller.script),
+        "open",
+        "https://example.com",
+    ]
+    assert calls == [expected]
+
+
+def test_click(monkeypatch):
+    calls = []
+    monkeypatch.setattr("subprocess.run", _fake_run(calls))
+    controller = SafariController()
+    controller.click("#btn")
+    expected = ["osascript", str(controller.script), "click", "#btn"]
+    assert calls == [expected]
+
+
+def test_fill(monkeypatch):
+    calls = []
+    monkeypatch.setattr("subprocess.run", _fake_run(calls))
+    controller = SafariController()
+    controller.fill("input", "hello")
+    expected = ["osascript", str(controller.script), "fill", "input", "hello"]
+    assert calls == [expected]
+
+
+def test_run_js(monkeypatch):
+    calls = []
+    monkeypatch.setattr("subprocess.run", _fake_run(calls))
+    controller = SafariController()
+    controller.run_js("2+2")
+    expected = ["osascript", str(controller.script), "run_js", "2+2"]
+    assert calls == [expected]
+
+
+def test_close_tab(monkeypatch):
+    calls = []
+    monkeypatch.setattr("subprocess.run", _fake_run(calls))
+    controller = SafariController()
+    controller.close_tab()
+    expected = ["osascript", str(controller.script), "close_tab"]
+    assert calls == [expected]


### PR DESCRIPTION
## Summary
- add SafariController wrapper around osascript
- create generic AppleScript for Safari automation
- refactor helper and Invoke task to use SafariController
- add unit tests for SafariController

## Testing
- `pre-commit run --files tasks/helpers.py tasks.py src/auto/automation/safari.py scripts/safari_control.scpt tests/test_safari_controller.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fabf019c832ab1e4ba39b06628cf