### PR TITLE
Fix SafariController JS result handling

### DIFF
--- a/src/auto/automation/safari.py
+++ b/src/auto/automation/safari.py
@@ -36,7 +36,8 @@ class SafariController:
 
     def run_js(self, code: str) -> str:
         """Execute JavaScript ``code`` in the current tab."""
-        return self._run("run_js", code)
+        result = self._run("run_js", code)
+        return result if result else "OK"
 
     def close_tab(self) -> str:
         """Close the current Safari tab."""


### PR DESCRIPTION
## Summary
- handle blank output from SafariController `run_js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878006309b0832a91a21aa580e62d42