### PR TITLE
Add pytest-recording for offline test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ marker:
 pytest -m integration
 ```
 
+### Network isolation
+
+Tests are executed with [`pytest-recording`](https://pypi.org/project/pytest-recording/)
+in `--block-network` mode. This prevents unexpected connections to the real
+internet. Recorded HTTP interactions are stored as VCR cassettes under a
+`cassettes/` directory next to each test module. To allow live recording or
+network access, override the default options:
+
+```bash
+pytest --record-mode=new_episodes
+```
+
+
 ## License
 
 Distributed under the [MIT License](LICENSE).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 markers =
     integration: tests that perform real network operations
-addopts = -m "not integration"
+addopts = -m "not integration" --block-network --record-mode=none
 # Dependencies are checked in tests/conftest.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,7 @@ pydantic_core==2.33.2
 Pygments==2.19.2
 PySocks==1.7.1
 pytest==8.4.1
+pytest-recording==0.13.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 python-magic==0.4.27


### PR DESCRIPTION
## Summary
- add `pytest-recording` to dependencies
- block network by default in pytest.ini
- document network isolation for tests

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ffeb9144832a90f56ff1a3fdc212