### PR TITLE
Implement plan parser and generate task files

### DIFF
--- a/src/auto/plan/parser.py
+++ b/src/auto/plan/parser.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable, List
+
+# Constants used for parsing
+HEADER_RE = re.compile(r"^(#+)\s+(.*)")
+BULLET_RE = re.compile(r"^\s*[-*]\s+(.*)")
+NUMBERED_RE = re.compile(r"^\s*(\d+)\.\s+(.*)")
+
+DEFAULT_OUTPUT_DIR = Path("src/plan")
+
+
+@dataclass
+class Task:
+    """Representation of a parsed plan task."""
+
+    id: str
+    heading: str
+    text: str
+
+
+def _write_tasks(tasks: Iterable[Task], out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for task in tasks:
+        path = out_dir / f"{task.id}.task"
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(asdict(task), fh, indent=2)
+
+
+def parse_plan(plan_file: Path, out_dir: Path = DEFAULT_OUTPUT_DIR) -> List[Task]:
+    """Parse a project plan into structured :class:`Task` objects.
+
+    Parameters
+    ----------
+    plan_file:
+        Path to the ``PLAN.md`` file.
+    out_dir:
+        Directory where ``*.task`` files will be written.
+
+    Returns
+    -------
+    List[Task]
+        Parsed tasks in the order they were encountered.
+    """
+
+    tasks: List[Task] = []
+    heading_stack: List[tuple[int, str]] = []
+    seq = 1
+
+    with Path(plan_file).open(encoding="utf-8") as fh:
+        for line in fh:
+            if m := HEADER_RE.match(line):
+                level = len(m.group(1))
+                text = m.group(2).strip()
+                while heading_stack and heading_stack[-1][0] >= level:
+                    heading_stack.pop()
+                heading_stack.append((level, text))
+                continue
+
+            if m := NUMBERED_RE.match(line):
+                text = m.group(2).strip()
+            elif m := BULLET_RE.match(line):
+                text = m.group(1).strip()
+            else:
+                continue
+
+
+            item_id = str(seq)
+            seq += 1
+
+            heading = " / ".join(h[1] for h in heading_stack)
+            tasks.append(Task(id=item_id, heading=heading, text=text))
+
+    _write_tasks(tasks, out_dir)
+    return tasks

--- a/src/plan/1.task
+++ b/src/plan/1.task
@@ -1,0 +1,5 @@
+{
+  "id": "1",
+  "heading": "Project Plan / Stand up CI/Dev environment",
+  "text": "Create the repository scaffold with `src/auto`, Alembic migrations, `tasks.py`, `.env` and `pre-commit`."
+}

--- a/src/plan/10.task
+++ b/src/plan/10.task
@@ -1,0 +1,5 @@
+{
+  "id": "10",
+  "heading": "Project Plan / Phase 1 \u2014 Core Pipeline MVP (1\u20132 weeks)",
+  "text": "Log results to the `post_status` table."
+}

--- a/src/plan/11.task
+++ b/src/plan/11.task
@@ -1,0 +1,5 @@
+{
+  "id": "11",
+  "heading": "Project Plan / Phase 1 \u2014 Core Pipeline MVP (1\u20132 weeks)",
+  "text": "A runnable script (cron or `invoke ingest`) that ingests the feed, normalizes posts, publishes to Mastodon and logs results."
+}

--- a/src/plan/12.task
+++ b/src/plan/12.task
@@ -1,0 +1,5 @@
+{
+  "id": "12",
+  "heading": "Project Plan / Phase 1 \u2014 Core Pipeline MVP (1\u20132 weeks)",
+  "text": "Unit tests covering each module."
+}

--- a/src/plan/13.task
+++ b/src/plan/13.task
@@ -1,0 +1,5 @@
+{
+  "id": "13",
+  "heading": "Project Plan / Phase 1 \u2014 Core Pipeline MVP (1\u20132 weeks)",
+  "text": "Baseline metrics from the first five posts (replies, boosts, favourites)."
+}

--- a/src/plan/14.task
+++ b/src/plan/14.task
@@ -1,0 +1,5 @@
+{
+  "id": "14",
+  "heading": "Project Plan / Phase 2 \u2014 Metric Collection & Scoring (1 week)",
+  "text": "Fetch engagement via the Mastodon API."
+}

--- a/src/plan/15.task
+++ b/src/plan/15.task
@@ -1,0 +1,5 @@
+{
+  "id": "15",
+  "heading": "Project Plan / Phase 2 \u2014 Metric Collection & Scoring (1 week)",
+  "text": "Compute `engagement_score` with configurable weights."
+}

--- a/src/plan/16.task
+++ b/src/plan/16.task
@@ -1,0 +1,5 @@
+{
+  "id": "16",
+  "heading": "Project Plan / Phase 2 \u2014 Metric Collection & Scoring (1 week)",
+  "text": "Persist scores back to the database."
+}

--- a/src/plan/17.task
+++ b/src/plan/17.task
@@ -1,0 +1,5 @@
+{
+  "id": "17",
+  "heading": "Project Plan / Phase 2 \u2014 Metric Collection & Scoring (1 week)",
+  "text": "Nightly job that retrieves engagement data and fills `metrics_*` fields."
+}

--- a/src/plan/18.task
+++ b/src/plan/18.task
@@ -1,0 +1,5 @@
+{
+  "id": "18",
+  "heading": "Project Plan / Phase 2 \u2014 Metric Collection & Scoring (1 week)",
+  "text": "Dashboard or notebook showing baseline scores for the first five posts."
+}

--- a/src/plan/19.task
+++ b/src/plan/19.task
@@ -1,0 +1,5 @@
+{
+  "id": "19",
+  "heading": "Project Plan / Phase 2 \u2014 Metric Collection & Scoring (1 week)",
+  "text": "Tests that simulate API responses and check the scoring logic."
+}

--- a/src/plan/2.task
+++ b/src/plan/2.task
@@ -1,0 +1,5 @@
+{
+  "id": "2",
+  "heading": "Project Plan / Stand up CI/Dev environment",
+  "text": "Install the testing framework (**pytest**) and code-quality hooks."
+}

--- a/src/plan/20.task
+++ b/src/plan/20.task
@@ -1,0 +1,5 @@
+{
+  "id": "20",
+  "heading": "Project Plan / Phase 3 \u2014 Lean Experiment Engine (2 weeks)",
+  "text": "Define variants and assign them (e.g. time slot or hook style)."
+}

--- a/src/plan/21.task
+++ b/src/plan/21.task
@@ -1,0 +1,5 @@
+{
+  "id": "21",
+  "heading": "Project Plan / Phase 3 \u2014 Lean Experiment Engine (2 weeks)",
+  "text": "Analysis job that compares average scores per variant using a statistical test."
+}

--- a/src/plan/22.task
+++ b/src/plan/22.task
@@ -1,0 +1,5 @@
+{
+  "id": "22",
+  "heading": "Project Plan / Phase 3 \u2014 Lean Experiment Engine (2 weeks)",
+  "text": "Planner that updates dispatcher config to use the winning variant."
+}

--- a/src/plan/23.task
+++ b/src/plan/23.task
@@ -1,0 +1,5 @@
+{
+  "id": "23",
+  "heading": "Project Plan / Phase 3 \u2014 Lean Experiment Engine (2 weeks)",
+  "text": "New `variant` column in `post_status`."
+}

--- a/src/plan/24.task
+++ b/src/plan/24.task
@@ -1,0 +1,5 @@
+{
+  "id": "24",
+  "heading": "Project Plan / Phase 3 \u2014 Lean Experiment Engine (2 weeks)",
+  "text": "Automated variant assignment during ingest."
+}

--- a/src/plan/25.task
+++ b/src/plan/25.task
@@ -1,0 +1,5 @@
+{
+  "id": "25",
+  "heading": "Project Plan / Phase 3 \u2014 Lean Experiment Engine (2 weeks)",
+  "text": "Daily analysis report and automatic config adjustment."
+}

--- a/src/plan/26.task
+++ b/src/plan/26.task
@@ -1,0 +1,5 @@
+{
+  "id": "26",
+  "heading": "Project Plan / Phase 3 \u2014 Lean Experiment Engine (2 weeks)",
+  "text": "Tests that mock variant data and validate the analysis logic."
+}

--- a/src/plan/27.task
+++ b/src/plan/27.task
@@ -1,0 +1,5 @@
+{
+  "id": "27",
+  "heading": "Project Plan / Phase 4 \u2014 Modular Plugins & Multi-Platform (3 weeks)",
+  "text": "Define a plugin interface with `post()` and `fetch_metrics()` methods."
+}

--- a/src/plan/28.task
+++ b/src/plan/28.task
@@ -1,0 +1,5 @@
+{
+  "id": "28",
+  "heading": "Project Plan / Phase 4 \u2014 Modular Plugins & Multi-Platform (3 weeks)",
+  "text": "Implement a Twitter/X plugin."
+}

--- a/src/plan/29.task
+++ b/src/plan/29.task
@@ -1,0 +1,5 @@
+{
+  "id": "29",
+  "heading": "Project Plan / Phase 4 \u2014 Modular Plugins & Multi-Platform (3 weeks)",
+  "text": "Refactor the dispatcher to iterate over enabled plugins."
+}

--- a/src/plan/3.task
+++ b/src/plan/3.task
@@ -1,0 +1,5 @@
+{
+  "id": "3",
+  "heading": "Project Plan / Agent integration",
+  "text": "Integrate the AI agent into the development loop via an editor extension or CLI wrapper so that it:"
+}

--- a/src/plan/30.task
+++ b/src/plan/30.task
@@ -1,0 +1,5 @@
+{
+  "id": "30",
+  "heading": "Project Plan / Phase 4 \u2014 Modular Plugins & Multi-Platform (3 weeks)",
+  "text": "Add a health-check job that pings each plugin."
+}

--- a/src/plan/31.task
+++ b/src/plan/31.task
@@ -1,0 +1,5 @@
+{
+  "id": "31",
+  "heading": "Project Plan / Phase 4 \u2014 Modular Plugins & Multi-Platform (3 weeks)",
+  "text": "`plugins/` folder with Mastodon and X modules."
+}

--- a/src/plan/32.task
+++ b/src/plan/32.task
@@ -1,0 +1,5 @@
+{
+  "id": "32",
+  "heading": "Project Plan / Phase 4 \u2014 Modular Plugins & Multi-Platform (3 weeks)",
+  "text": "Dispatcher that fans out to both platforms."
+}

--- a/src/plan/33.task
+++ b/src/plan/33.task
@@ -1,0 +1,5 @@
+{
+  "id": "33",
+  "heading": "Project Plan / Phase 4 \u2014 Modular Plugins & Multi-Platform (3 weeks)",
+  "text": "Health-check alerts sent to Slack or email."
+}

--- a/src/plan/34.task
+++ b/src/plan/34.task
@@ -1,0 +1,5 @@
+{
+  "id": "34",
+  "heading": "Project Plan / Phase 4 \u2014 Modular Plugins & Multi-Platform (3 weeks)",
+  "text": "Integration tests using mocks for each plugin."
+}

--- a/src/plan/35.task
+++ b/src/plan/35.task
@@ -1,0 +1,5 @@
+{
+  "id": "35",
+  "heading": "Project Plan / Phase 5 \u2014 Self-Healing & Vision-Driven Fallback (4 weeks)",
+  "text": "Error detector that flags repeated failures."
+}

--- a/src/plan/36.task
+++ b/src/plan/36.task
@@ -1,0 +1,5 @@
+{
+  "id": "36",
+  "heading": "Project Plan / Phase 5 \u2014 Self-Healing & Vision-Driven Fallback (4 weeks)",
+  "text": "Vision-based MCP script template (e.g. Lackey or Airtest)."
+}

--- a/src/plan/37.task
+++ b/src/plan/37.task
@@ -1,0 +1,5 @@
+{
+  "id": "37",
+  "heading": "Project Plan / Phase 5 \u2014 Self-Healing & Vision-Driven Fallback (4 weeks)",
+  "text": "Agent prompt design that reads error logs, infers new selectors or templates and generates updated plugin code."
+}

--- a/src/plan/38.task
+++ b/src/plan/38.task
@@ -1,0 +1,5 @@
+{
+  "id": "38",
+  "heading": "Project Plan / Phase 5 \u2014 Self-Healing & Vision-Driven Fallback (4 weeks)",
+  "text": "CI pipeline step that runs MCP flows nightly against a staging page."
+}

--- a/src/plan/39.task
+++ b/src/plan/39.task
@@ -1,0 +1,5 @@
+{
+  "id": "39",
+  "heading": "Project Plan / Phase 5 \u2014 Self-Healing & Vision-Driven Fallback (4 weeks)",
+  "text": "Automated fallback pipeline that switches to browser-based MCP mode on API failure."
+}

--- a/src/plan/4.task
+++ b/src/plan/4.task
@@ -1,0 +1,5 @@
+{
+  "id": "4",
+  "heading": "Project Plan / Agent integration",
+  "text": "Reads Rotex specs."
+}

--- a/src/plan/40.task
+++ b/src/plan/40.task
@@ -1,0 +1,5 @@
+{
+  "id": "40",
+  "heading": "Project Plan / Phase 5 \u2014 Self-Healing & Vision-Driven Fallback (4 weeks)",
+  "text": "AI-generated pull requests for selector updates, validated by tests."
+}

--- a/src/plan/41.task
+++ b/src/plan/41.task
@@ -1,0 +1,5 @@
+{
+  "id": "41",
+  "heading": "Project Plan / Phase 5 \u2014 Self-Healing & Vision-Driven Fallback (4 weeks)",
+  "text": "Dashboard of connector uptime and auto-healing actions."
+}

--- a/src/plan/42.task
+++ b/src/plan/42.task
@@ -1,0 +1,5 @@
+{
+  "id": "42",
+  "heading": "Project Plan / Phase 6 \u2014 Continuous Meta-Automation (ongoing)",
+  "text": "Generator that scans analytics and suggests new hypotheses (e.g. \"Test 3-tag vs 5-tag sets on X\")."
+}

--- a/src/plan/43.task
+++ b/src/plan/43.task
@@ -1,0 +1,5 @@
+{
+  "id": "43",
+  "heading": "Project Plan / Phase 6 \u2014 Continuous Meta-Automation (ongoing)",
+  "text": "Agent to scaffold new Rotex specs and submit pull requests for review."
+}

--- a/src/plan/44.task
+++ b/src/plan/44.task
@@ -1,0 +1,5 @@
+{
+  "id": "44",
+  "heading": "Project Plan / Phase 6 \u2014 Continuous Meta-Automation (ongoing)",
+  "text": "Code-refactor alerts (e.g. duplicated code in plugins)."
+}

--- a/src/plan/45.task
+++ b/src/plan/45.task
@@ -1,0 +1,5 @@
+{
+  "id": "45",
+  "heading": "Project Plan / Phase 6 \u2014 Continuous Meta-Automation (ongoing)",
+  "text": "A \"lab notebook\" CLI where generated specs can be approved or refined."
+}

--- a/src/plan/46.task
+++ b/src/plan/46.task
@@ -1,0 +1,5 @@
+{
+  "id": "46",
+  "heading": "Project Plan / Phase 6 \u2014 Continuous Meta-Automation (ongoing)",
+  "text": "Periodic pull requests that expand test coverage or clean up code."
+}

--- a/src/plan/47.task
+++ b/src/plan/47.task
@@ -1,0 +1,5 @@
+{
+  "id": "47",
+  "heading": "Project Plan / Phase 6 \u2014 Continuous Meta-Automation (ongoing)",
+  "text": "A living system that, with minimal human guidance, writes new code to pursue higher engagement."
+}

--- a/src/plan/48.task
+++ b/src/plan/48.task
@@ -1,0 +1,5 @@
+{
+  "id": "48",
+  "heading": "Project Plan / Parallel activities",
+  "text": "Governance & review: weekly sprint check-ins to review AI-generated pull requests and metrics."
+}

--- a/src/plan/49.task
+++ b/src/plan/49.task
@@ -1,0 +1,5 @@
+{
+  "id": "49",
+  "heading": "Project Plan / Parallel activities",
+  "text": "Data-driven calibration: quarterly weight recalibration for the engagement formula."
+}

--- a/src/plan/5.task
+++ b/src/plan/5.task
@@ -1,0 +1,5 @@
+{
+  "id": "5",
+  "heading": "Project Plan / Agent integration",
+  "text": "Generates code files or pull requests."
+}

--- a/src/plan/50.task
+++ b/src/plan/50.task
@@ -1,0 +1,5 @@
+{
+  "id": "50",
+  "heading": "Project Plan / Parallel activities",
+  "text": "User feedback: early beta testers providing qualitative feedback to refine normalization, tone and variant dimensions."
+}

--- a/src/plan/6.task
+++ b/src/plan/6.task
@@ -1,0 +1,5 @@
+{
+  "id": "6",
+  "heading": "Project Plan / Agent integration",
+  "text": "Runs tests and reports results."
+}

--- a/src/plan/7.task
+++ b/src/plan/7.task
@@ -1,0 +1,5 @@
+{
+  "id": "7",
+  "heading": "Project Plan / Phase 1 \u2014 Core Pipeline MVP (1\u20132 weeks)",
+  "text": "Poll & parse Substack RSS."
+}

--- a/src/plan/8.task
+++ b/src/plan/8.task
@@ -1,0 +1,5 @@
+{
+  "id": "8",
+  "heading": "Project Plan / Phase 1 \u2014 Core Pipeline MVP (1\u20132 weeks)",
+  "text": "Normalize entries and generate excerpts."
+}

--- a/src/plan/9.task
+++ b/src/plan/9.task
@@ -1,0 +1,5 @@
+{
+  "id": "9",
+  "heading": "Project Plan / Phase 1 \u2014 Core Pipeline MVP (1\u20132 weeks)",
+  "text": "Post to Mastodon."
+}


### PR DESCRIPTION
## Summary
- implement parser for PLAN.md
- generate `src/plan/*.task` files

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e7b66d6c832aa0de70ff17be3ff6