### PR TITLE
Add parse_plan tests

### DIFF
--- a/tests/test_plan_parser.py
+++ b/tests/test_plan_parser.py
@@ -1,0 +1,37 @@
+import textwrap
+from pathlib import Path
+from auto.plan.parser import parse_plan
+
+
+def test_parse_plan_basic(tmp_path):
+    sample = textwrap.dedent(
+        """
+        # Roadmap
+
+        ## Setup
+        - Install dependencies
+        - Run tests
+
+        ## Deploy
+        1. Build image
+        2. Push to registry
+        """
+    )
+    plan = tmp_path / "plan.md"
+    plan.write_text(sample)
+
+    tasks = parse_plan(plan, out_dir=tmp_path)
+
+    assert [t.id for t in tasks] == ["1", "2", "3", "4"]
+    assert [t.heading for t in tasks] == [
+        "Roadmap / Setup",
+        "Roadmap / Setup",
+        "Roadmap / Deploy",
+        "Roadmap / Deploy",
+    ]
+    assert [t.text for t in tasks] == [
+        "Install dependencies",
+        "Run tests",
+        "Build image",
+        "Push to registry",
+    ]


### PR DESCRIPTION
## Summary
- test parsing simple plans using `parse_plan`

## Testing
- `pytest tests/test_plan_parser.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878eb576ff8832aa4a3b38dfde0c3c6