### PR TITLE
Add code synthesizer skeleton

### DIFF
--- a/src/auto/code_synthesizer.py
+++ b/src/auto/code_synthesizer.py
@@ -1,0 +1,37 @@
+"""Utilities for code synthesis based on repository context."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import List
+
+from . import configure_logging
+
+logger = logging.getLogger(__name__)
+
+
+class CodeSynthesizer:
+    """Generate code for function specifications."""
+
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = Path(repo_root)
+
+    def _collect_files(self, base: Path, limit: int) -> List[Path]:
+        return list(base.rglob("*.py"))[:limit]
+
+    def synthesize(self, function_spec: dict) -> List[Path]:
+        """Return repository files relevant to ``function_spec``."""
+        configure_logging()
+        file_limit = int(os.getenv("CODE_SYNTH_FILE_LIMIT", "20"))
+        src_dir = self.repo_root / "src" / "auto"
+        mig_dir = self.repo_root / "alembic" / "versions"
+        context_path = self.repo_root / "CONTEXT.md"
+        context = context_path.read_text(encoding="utf-8")
+        logger.debug("Loaded context: %s...", context[:100])
+        files = self._collect_files(src_dir, file_limit)
+        files += self._collect_files(mig_dir, file_limit)
+        logger.info("Prepared repository context with %d files", len(files))
+        # Placeholder for real synthesis
+        return files

--- a/tests/test_code_synthesizer.py
+++ b/tests/test_code_synthesizer.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+from auto.code_synthesizer import CodeSynthesizer
+
+
+@pytest.fixture
+def sample_repo(tmp_path):
+    (tmp_path / "CONTEXT.md").write_text("context")
+    src = tmp_path / "src" / "auto"
+    src.mkdir(parents=True)
+    (src / "a.py").write_text("a = 1")
+    (src / "b.py").write_text("b = 2")
+    mig = tmp_path / "alembic" / "versions"
+    mig.mkdir(parents=True)
+    (mig / "m.py").write_text("m = 3")
+    return tmp_path
+
+
+def test_synthesize_uses_env_variable(sample_repo, monkeypatch):
+    def fake_collect(self, base: Path, limit: int):
+        return [base / "dummy.py"] * limit
+
+    monkeypatch.setattr(CodeSynthesizer, "_collect_files", fake_collect)
+    cs = CodeSynthesizer(sample_repo)
+
+    monkeypatch.setenv("CODE_SYNTH_FILE_LIMIT", "1")
+    result1 = cs.synthesize({})
+    assert len(result1) == 2
+
+    monkeypatch.setenv("CODE_SYNTH_FILE_LIMIT", "3")
+    result2 = cs.synthesize({})
+    assert len(result2) == 6
+
+
+def test_synthesize_reads_context(sample_repo, monkeypatch):
+    captured = {"configured": False, "read": 0}
+
+    def fake_configure():
+        captured["configured"] = True
+
+    def fake_read_text(self, encoding="utf-8"):
+        if self.name == "CONTEXT.md":
+            captured["read"] += 1
+        return "context"
+
+    monkeypatch.setattr("auto.code_synthesizer.configure_logging", fake_configure)
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+    cs = CodeSynthesizer(sample_repo)
+    cs.synthesize({})
+
+    assert captured["configured"]
+    assert captured["read"] == 1


### PR DESCRIPTION
## Summary
- add `CodeSynthesizer` helper for scanning repo context
- integrate logging initialization via `configure_logging`
- respect `CODE_SYNTH_FILE_LIMIT` environment variable
- test environment handling and configuration

## Testing
- `pre-commit run --files src/auto/code_synthesizer.py tests/test_code_synthesizer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f0abedd4832aae8f6ceef81e4ea4