### PR TITLE
Improve UTC handling for scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ post’s publish status per network is tracked in the `post_status` table.
 While minimal, the goal is to provide the scaffolding for mirroring your
 Substack content across multiple social sites with a single workflow.
 
+### Scheduling posts
+
+Posts are queued with the `invoke schedule` task. The time argument accepts
+absolute ISO timestamps or relative values like `"+30m"`. Timestamps without a
+timezone are interpreted in UTC and stored as timezone-aware datetimes.
+
 ## Managing previews
 
 Previews are small templates used when posting to other networks. They can be listed, generated or edited with Invoke tasks:

--- a/src/auto/models.py
+++ b/src/auto/models.py
@@ -1,6 +1,28 @@
 from datetime import datetime, timezone
 
 from sqlalchemy import Column, String, Text, Integer, DateTime, ForeignKey, text
+from sqlalchemy.types import TypeDecorator
+
+
+class TZDateTime(TypeDecorator):
+    """A timezone-aware DateTime that normalizes to UTC."""
+
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
 from .db import Base
 
@@ -14,12 +36,12 @@ class Post(Base):
     summary = Column(Text)
     published = Column(String)
     created_at = Column(
-        DateTime(timezone=True),
+        TZDateTime(),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
     )
     updated_at = Column(
-        DateTime(timezone=True),
+        TZDateTime(),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
         onupdate=lambda: datetime.now(timezone.utc),
@@ -32,7 +54,7 @@ class PostStatus(Base):
     post_id = Column(String, ForeignKey("posts.id"), primary_key=True)
     network = Column(String, primary_key=True)
     scheduled_at = Column(
-        DateTime(timezone=True),
+        TZDateTime(),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
     )
@@ -40,7 +62,7 @@ class PostStatus(Base):
     attempts = Column(Integer, nullable=False, server_default="0")
     last_error = Column(Text)
     updated_at = Column(
-        DateTime(timezone=True),
+        TZDateTime(),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
         onupdate=lambda: datetime.now(timezone.utc),
@@ -54,7 +76,7 @@ class PostPreview(Base):
     network = Column(String, primary_key=True)
     content = Column(Text, nullable=False)
     updated_at = Column(
-        DateTime(timezone=True),
+        TZDateTime(),
         nullable=False,
         server_default=text("CURRENT_TIMESTAMP"),
         onupdate=lambda: datetime.now(timezone.utc),

--- a/tasks.py
+++ b/tasks.py
@@ -71,13 +71,10 @@ def schedule(ctx, post_id, time, network=None):
     ``"in 1h"`` or ``"+30m"``. If ``--network`` is omitted the post is
     scheduled for all known networks.
     """
-    from datetime import timezone
     from auto.db import SessionLocal
     from auto.models import Post, PostStatus
 
     scheduled_at = _parse_when(time)
-    if scheduled_at.tzinfo is not None:
-        scheduled_at = scheduled_at.astimezone(timezone.utc)
     networks = [network] if network else ["mastodon"]
 
     with SessionLocal() as session:

--- a/tasks/helpers.py
+++ b/tasks/helpers.py
@@ -12,7 +12,10 @@ from dateutil import parser
 
 
 def _parse_when(value: str) -> datetime:
-    """Parse relative or absolute time specifications."""
+    """Parse relative or absolute time specifications.
+
+    Always return a timezone-aware UTC datetime.
+    """
     value = value.strip().lower()
     m = re.match(r"(?:in\s+|\+)?(\d+)([smhd])$", value)
     if m:
@@ -24,7 +27,11 @@ def _parse_when(value: str) -> datetime:
             "d": timedelta(days=int(amount)),
         }[unit]
         return datetime.now(timezone.utc) + delta
-    return parser.isoparse(value)
+
+    dt = parser.isoparse(value)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
 
 
 def _get_medium_magic_link() -> str | None:

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -15,3 +15,29 @@ def test_schedule_missing_post(monkeypatch, test_db_engine, capsys):
         statuses = session.query(PostStatus).all()
         assert statuses == []
 
+
+def test_schedule_naive_timestamp(test_db_engine):
+    from datetime import datetime, timezone
+    from auto.models import Post
+
+    ts = "2023-01-02T12:34:56"
+    with SessionLocal() as session:
+        session.add(
+            Post(
+                id="1",
+                title="Title",
+                link="http://example",
+                summary="",
+                published="",
+            )
+        )
+        session.commit()
+
+    tasks.schedule(Context(), post_id="1", time=ts)
+
+    with SessionLocal() as session:
+        ps = session.get(PostStatus, {"post_id": "1", "network": "mastodon"})
+        assert ps is not None
+        assert ps.scheduled_at == datetime(2023, 1, 2, 12, 34, 56, tzinfo=timezone.utc)
+        assert ps.scheduled_at.tzinfo is timezone.utc
+


### PR DESCRIPTION
## Summary
- ensure `_parse_when` always returns timezone-aware UTC datetimes
- simplify `schedule` task by trusting the helper
- keep datetimes in UTC when loaded from the DB
- test scheduling of naive timestamps
- document behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f05f8f98832a9f6236470cfea8b5