### PR TITLE
Fix unrecognized pytest options

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,10 @@ python -c 'from auto.plan.parser import parse_plan; parse_plan("PLAN.md")'
 
 ## Running tests
 
-Before running tests, install the project dependencies:
+Before running tests, install the project dependencies. The
+`pytest-recording` plugin is included here and provides the
+`--block-network` and `--record-mode` options configured in
+`pytest.ini`:
 
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- clarify that installing requirements.txt provides pytest-recording and its command line options

## Testing
- `pytest -k ""`

------
https://chatgpt.com/codex/tasks/task_e_6878f24fec14832a8a5f8fea18c1e2cb