### PR TITLE
Add HTML link extraction helper and tests

### DIFF
--- a/src/auto/html_utils.py
+++ b/src/auto/html_utils.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import List
+
+from bs4 import BeautifulSoup
+
+
+def extract_links_with_green_span(html: str) -> List[str]:
+    """Return hrefs for anchors containing a ``text-green-500`` span."""
+    soup = BeautifulSoup(html, "html.parser")
+    links: List[str] = []
+    for a in soup.find_all("a", href=True):
+        if a.find("span", class_="text-green-500"):
+            links.append(a["href"])
+    return links

--- a/tests/test_html_utils.py
+++ b/tests/test_html_utils.py
@@ -1,0 +1,11 @@
+from auto.html_utils import extract_links_with_green_span
+
+
+def test_extract_links_with_green_span():
+    html = """
+    <div><a href='/task1'><span class='text-green-500'>+1</span></a></div>
+    <div><a href='/task2'><span class='text-red-500'>-1</span></a></div>
+    <div><a href='/task3'><span class='text-green-500'>+2</span></a></div>
+    """
+    links = extract_links_with_green_span(html)
+    assert links == ['/task1', '/task3']


### PR DESCRIPTION
## Summary
- add `extract_links_with_green_span` helper for parsing HTML
- test extracting hrefs only when `text-green-500` spans exist

## Testing
- `pytest tests/test_html_utils.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792a0d0bd4832a90d0ff295a0fe967