### PR TITLE
Ignore merged PRs when extracting links

### DIFF
--- a/src/auto/html_utils.py
+++ b/src/auto/html_utils.py
@@ -6,10 +6,21 @@ from bs4 import BeautifulSoup
 
 
 def extract_links_with_green_span(html: str) -> List[str]:
-    """Return hrefs for anchors containing a ``text-green-500`` span."""
+    """Return hrefs for anchors containing a ``text-green-500`` span.
+
+    Links are ignored when the surrounding element also includes the word
+    ``Merged``. This matches the structure of GitHub's pull request list where
+    merged PRs show a ``Merged`` badge next to the link.
+    """
     soup = BeautifulSoup(html, "html.parser")
     links: List[str] = []
     for a in soup.find_all("a", href=True):
-        if a.find("span", class_="text-green-500"):
-            links.append(a["href"])
+        if not a.find("span", class_="text-green-500"):
+            continue
+
+        container_text = a.parent.get_text(" ", strip=True).lower()
+        if "merged" in container_text:
+            continue
+
+        links.append(a["href"])
     return links

--- a/tests/test_html_utils.py
+++ b/tests/test_html_utils.py
@@ -9,3 +9,17 @@ def test_extract_links_with_green_span():
     """
     links = extract_links_with_green_span(html)
     assert links == ['/task1', '/task3']
+
+
+def test_extract_links_skips_merged_items():
+    html = """
+    <div>
+      <a href='/task1'><span class='text-green-500'>+1</span></a>
+      <button><svg></svg>Merged</button>
+    </div>
+    <div>
+      <a href='/task2'><span class='text-green-500'>+2</span></a>
+    </div>
+    """
+    links = extract_links_with_green_span(html)
+    assert links == ['/task2']


### PR DESCRIPTION
## Summary
- avoid returning links to merged PRs when parsing HTML
- expand tests to cover merged PR items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792c34d0fc832a9c56b400846f900d