### PR TITLE
Add link count helper

### DIFF
--- a/src/auto/html_helpers.py
+++ b/src/auto/html_helpers.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import httpx
+from bs4 import BeautifulSoup
+
+from .automation.safari import SafariController
+from .html_utils import extract_links_with_green_span
+
+
+def fetch_dom(url: str = "https://chatgpt.com/codex") -> str:
+    """Return the full DOM tree for ``url`` using Safari."""
+    controller = SafariController()
+    controller.open(url)
+    return controller.run_js("document.documentElement.outerHTML")
+
+
+def download_html(url: str) -> str:
+    """Return the HTML contents of ``url``."""
+    response = httpx.get(url, timeout=10)
+    response.raise_for_status()
+    return response.text
+
+
+def count_link_states(html: str) -> tuple[int, int]:
+    """Return counts for merged and active links from ``html``."""
+    soup = BeautifulSoup(html, "html.parser")
+    merged = 0
+    for a in soup.find_all("a", href=True):
+        if not a.find("span", class_="text-green-500"):
+            continue
+        container_text = a.parent.get_text(" ", strip=True).lower()
+        if "merged" in container_text:
+            merged += 1
+    active = len(extract_links_with_green_span(html))
+    return merged, active

--- a/tasks.py
+++ b/tasks.py
@@ -10,6 +10,11 @@ from tasks.helpers import (
     update_dependencies,
 )
 from auto.automation.safari import SafariController
+from auto.html_helpers import (
+    fetch_dom as fetch_dom_html,
+    download_html,
+    count_link_states,
+)
 
 
 @task
@@ -244,12 +249,18 @@ def codex_todo(ctx):
 @task
 def fetch_dom(ctx):
     """Open the Codex page and print the full DOM tree."""
-
-    controller = SafariController()
-    controller.open("https://chatgpt.com/codex")
-    dom = controller.run_js("document.documentElement.outerHTML")
+    dom = fetch_dom_html()
     if dom:
         print(dom)
+
+
+@task
+def count_links(ctx, url="https://github.com/gducharme/auto/pulls"):
+    """Download ``url`` and report merged vs active link counts."""
+    html = download_html(url)
+    merged, active = count_link_states(html)
+    print(f"Merged links: {merged}")
+    print(f"Active tasks: {active}")
 
 
 @task

--- a/tests/test_html_helpers.py
+++ b/tests/test_html_helpers.py
@@ -1,0 +1,19 @@
+from auto.html_helpers import count_link_states
+
+
+def test_count_link_states():
+    html = """
+    <div>
+      <a href='/pr1'><span class='text-green-500'>+1</span></a>
+      <span>Merged</span>
+    </div>
+    <div>
+      <a href='/pr2'><span class='text-green-500'>+2</span></a>
+    </div>
+    <div>
+      <a href='/pr3'><span class='text-green-500'>+3</span></a>
+    </div>
+    """
+    merged, active = count_link_states(html)
+    assert merged == 1
+    assert active == 2


### PR DESCRIPTION
## Summary
- add `html_helpers` module to fetch DOM, download HTML, and count links
- use helpers in `tasks.fetch_dom` and add new `count_links` task
- test the DOM counting helper

## Testing
- `pre-commit run --files src/auto/html_helpers.py tasks.py tests/test_html_helpers.py`
- `pytest tests/test_html_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_6879301fbad0832abdbf8d978a8343fa