### PR TITLE
Update merge bot and slow print

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -21,9 +21,9 @@ from auto.html_utils import extract_links_with_green_span
 
 
 def _slow_print(message: str) -> None:
-    """Sleep 10 seconds before printing the message."""
-    time.sleep(10)
+    """Print ``message`` then pause for 10 seconds."""
     print(message)
+    time.sleep(10)
 
 
 @task
@@ -297,6 +297,11 @@ def merge_bot(ctx, codex_url="https://chatgpt.com/codex"):
 
     pr_url = links[0]
     # the links are broken without domain. add it back in
+    if not pr_url.startswith("http"):
+        from urllib.parse import urljoin
+
+        pr_url = urljoin(codex_url, pr_url)
+
     _slow_print(f"Opening PR link: {pr_url}")
     controller.open(pr_url)
 
@@ -306,7 +311,6 @@ def merge_bot(ctx, codex_url="https://chatgpt.com/codex"):
         "return l?l.href:'';"
         "})()"
     )
-    # use controller.open instead
     github_url = controller.run_js(github_js)
     if not github_url:
         _slow_print("GitHub link not found")

--- a/tests/test_merge_bot.py
+++ b/tests/test_merge_bot.py
@@ -62,6 +62,6 @@ def test_merge_bot_no_pr(monkeypatch):
     tasks.merge_bot(Context())
 
     assert controller.calls == [
-        ("open", "https://chatgpt.com/kodex"),
+        ("open", "https://chatgpt.com/codex"),
         ("run_js", "document.documentElement.outerHTML"),
     ]


### PR DESCRIPTION
## Summary
- print message before sleeping in `_slow_print`
- ensure merge bot uses absolute PR links
- update merge bot test to use codex URL

## Testing
- `pytest -q tests/test_merge_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6879434b4a34832a95b618a61aeaa367