### PR TITLE
Fix timezone handling in schedule helpers

### DIFF
--- a/alembic/versions/0004_timezone_aware_post_status.py
+++ b/alembic/versions/0004_timezone_aware_post_status.py
@@ -1,0 +1,49 @@
+"""Ensure stored scheduled_at values have timezone info
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2025-07-19 00:00:00
+"""
+
+from typing import Sequence, Union
+from datetime import timezone
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0004"
+down_revision: Union[str, Sequence[str], None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    post_status = sa.table(
+        "post_status",
+        sa.column("post_id", sa.String()),
+        sa.column("network", sa.String()),
+        sa.column("scheduled_at", sa.DateTime()),
+    )
+
+    rows = conn.execute(
+        sa.select(post_status.c.post_id, post_status.c.network, post_status.c.scheduled_at)
+    ).fetchall()
+
+    for pid, net, ts in rows:
+        if ts is not None and getattr(ts, "tzinfo", None) is None:
+            aware = ts.replace(tzinfo=timezone.utc)
+            conn.execute(
+                post_status.update()
+                .where(
+                    post_status.c.post_id == pid,
+                    post_status.c.network == net,
+                )
+                .values(scheduled_at=aware)
+            )
+
+
+def downgrade() -> None:
+    pass
+

--- a/tasks/helpers.py
+++ b/tasks/helpers.py
@@ -16,8 +16,8 @@ def _parse_when(value: str) -> datetime:
 
     Always return a timezone-aware UTC datetime.
     """
-    value = value.strip().lower()
-    m = re.match(r"(?:in\s+|\+)?(\d+)([smhd])$", value)
+    value = value.strip()
+    m = re.match(r"(?:in\s+|\+)?(\d+)([smhd])$", value.lower())
     if m:
         amount, unit = m.groups()
         delta = {
@@ -30,8 +30,10 @@ def _parse_when(value: str) -> datetime:
 
     dt = parser.isoparse(value)
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt
 
 
 def _get_medium_magic_link() -> str | None:

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,6 +1,7 @@
 from invoke import Context
 
 import tasks  # noqa: E402
+from tasks.helpers import _parse_when  # noqa: E402
 from auto.db import SessionLocal  # noqa: E402
 from auto.models import PostStatus
 
@@ -40,4 +41,46 @@ def test_schedule_naive_timestamp(test_db_engine):
         assert ps is not None
         assert ps.scheduled_at == datetime(2023, 1, 2, 12, 34, 56, tzinfo=timezone.utc)
         assert ps.scheduled_at.tzinfo is timezone.utc
+
+
+def test_schedule_aware_timestamp(test_db_engine):
+    from datetime import datetime, timezone
+    from auto.models import Post
+
+    ts = "2023-01-02T12:34:56-05:00"
+    with SessionLocal() as session:
+        session.add(
+            Post(
+                id="2",
+                title="Title",
+                link="http://example",
+                summary="",
+                published="",
+            )
+        )
+        session.commit()
+
+    tasks.schedule(Context(), post_id="2", time=ts)
+
+    with SessionLocal() as session:
+        ps = session.get(PostStatus, {"post_id": "2", "network": "mastodon"})
+        assert ps is not None
+        assert ps.scheduled_at == datetime(2023, 1, 2, 17, 34, 56, tzinfo=timezone.utc)
+        assert ps.scheduled_at.tzinfo is timezone.utc
+
+
+def test_parse_when_naive():
+    from datetime import datetime, timezone
+
+    result = _parse_when("2023-01-02T01:02:03")
+    assert result == datetime(2023, 1, 2, 1, 2, 3, tzinfo=timezone.utc)
+    assert result.tzinfo is timezone.utc
+
+
+def test_parse_when_aware():
+    from datetime import datetime, timezone
+
+    result = _parse_when("2023-01-02T01:02:03+02:00")
+    assert result == datetime(2023, 1, 1, 23, 2, 3, tzinfo=timezone.utc)
+    assert result.tzinfo is timezone.utc
 


### PR DESCRIPTION
## Summary
- ensure `_parse_when()` normalizes timestamps to UTC
- add regression tests covering naive and aware inputs
- migrate existing schedule records to include timezone info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4a05cbb0832ab568adbae2a73da1