### PR TITLE
Fix github-bot parsing

### DIFF
--- a/src/auto/html_utils.py
+++ b/src/auto/html_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import List
 
 from bs4 import BeautifulSoup
+import re
 
 
 def extract_links_with_green_span(html: str) -> List[str]:
@@ -24,3 +25,26 @@ def extract_links_with_green_span(html: str) -> List[str]:
 
         links.append(a["href"])
     return links
+
+
+def parse_codex_tasks(html: str) -> List[dict]:
+    """Return task info dictionaries extracted from Codex HTML.
+
+    Each returned dict contains ``text`` with the row text, ``status`` which is
+    either ``"Merged"`` or ``"Open"`` (or ``None`` if neither is present), and a
+    boolean ``code`` flag indicating whether the row includes code changes.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    rows = soup.select("div.task-row-container")
+    tasks: List[dict] = []
+    for row in rows:
+        text = row.get_text(" ", strip=True)
+        if "Merged" in text:
+            status = "Merged"
+        elif "Open" in text:
+            status = "Open"
+        else:
+            status = None
+        code = bool(re.search(r"\+[0-9]+", text))
+        tasks.append({"text": text, "status": status, "code": code})
+    return tasks

--- a/tasks.py
+++ b/tasks.py
@@ -19,7 +19,7 @@ from auto.html_helpers import (
     fetch_dom as fetch_dom_html,
     count_link_states,
 )
-from auto.html_utils import extract_links_with_green_span
+from auto.html_utils import extract_links_with_green_span, parse_codex_tasks
 
 
 def _delay(seconds: float) -> None:
@@ -345,12 +345,8 @@ def github_bot(ctx, codex_url="https://chatgpt.com/codex"):
     dom = controller.run_js("document.documentElement.outerHTML")
     _slow_print("Scanning for Open button")
 
-    soup = BeautifulSoup(dom, "html.parser")
-    found = any(
-        span.find_parent("button") is not None and "Open" in span.get_text()
-        for span in soup.find_all("span")
-    )
-    if not found:
+    tasks = parse_codex_tasks(dom)
+    if not any(t["status"] == "Open" for t in tasks):
         _slow_print("Open button not found")
         return
 

--- a/tests/test_parse_codex_tasks.py
+++ b/tests/test_parse_codex_tasks.py
@@ -1,0 +1,12 @@
+import pathlib
+from auto.html_utils import parse_codex_tasks
+
+
+def test_parse_codex_tasks():
+    html = pathlib.Path('tests/fixtures/dom.html').read_text()
+    tasks = parse_codex_tasks(html)
+    assert len(tasks) == 6
+    statuses = [t['status'] for t in tasks]
+    assert statuses.count('Merged') == 2
+    assert statuses.count('Open') == 1
+    assert sum(1 for t in tasks if not t['code']) == 3


### PR DESCRIPTION
## Summary
- parse Codex task rows from HTML to detect statuses
- update github_bot task to use the new parser
- test parsing with provided DOM fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a49b6a410832a95762bcdea6d22b9