### PR TITLE
Enable test coverage reporting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 ## Low Priority
 - Expand social network support beyond Mastodon.
 - Containerize the application with a Dockerfile.
-- Add code coverage reporting for the test suite.
+- ~~Add code coverage reporting for the test suite.~~
 
 ## Code Smells
 - Unused imports reported by `ruff` should be cleaned up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest",
+  "pytest-cov",
   "ruff",
   "black",
   "pre-commit",

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,6 +73,7 @@ Pygments==2.19.2
 PySocks==1.7.1
 pytest==8.4.1
 pytest-recording==0.13.1
+pytest-cov==6.2.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 python-magic==0.4.27

--- a/tasks/helpers.py
+++ b/tasks/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 from datetime import datetime, timedelta, timezone
@@ -120,7 +121,11 @@ def _ci(ctx, upgrade: bool = False, freeze: bool = False) -> None:
     ctx.run("alembic upgrade head", pty=True, echo=True)
     ctx.run("pre-commit run --all-files", pty=True, echo=True)
 
-    test_res = ctx.run("pytest --cov", warn=True, pty=True, echo=True)
+    cmd = "pytest --cov=src/auto --cov-report=term --cov-report=xml"
+    if os.getenv("COVERAGE_HTML"):
+        cmd += " --cov-report=html"
+
+    test_res = ctx.run(cmd, warn=True, pty=True, echo=True)
 
     coverage = None
     for line in test_res.stdout.splitlines():


### PR DESCRIPTION
## Summary
- add `pytest-cov` to development requirements
- optionally output HTML coverage reports
- report coverage percentage from CI helper
- mark coverage TODO item as complete

## Testing
- `pre-commit run --files requirements.txt pyproject.toml tasks/helpers.py TODO.md`
- `pytest --cov=src/auto --cov-report=term --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4a1cab74832a980ed9a8850fc4ef