### PR TITLE
Fix parse_codex_tasks test counts

### DIFF
--- a/tests/test_parse_codex_tasks.py
+++ b/tests/test_parse_codex_tasks.py
@@ -5,8 +5,8 @@ from auto.html_utils import parse_codex_tasks
 def test_parse_codex_tasks():
     html = pathlib.Path("tests/fixtures/dom.html").read_text()
     tasks = parse_codex_tasks(html)
-    assert len(tasks) == 6
+    assert len(tasks) == 8
     statuses = [t["status"] for t in tasks]
-    assert statuses.count("Merged") == 2
+    assert statuses.count("Merged") == 3
     assert statuses.count("Open") == 1
-    assert sum(1 for t in tasks if not t["code"]) == 3
+    assert sum(1 for t in tasks if not t["code"]) == 4


### PR DESCRIPTION
## Summary
- check a larger DOM fixture for parsed tasks
- update `test_parse_codex_tasks` expectations

## Testing
- `pytest -k parse_codex_tasks -vv`

------
https://chatgpt.com/codex/tasks/task_e_687a62e2169c832a94414f2284889475