### PR TITLE
Add supervisor replan loop

### DIFF
--- a/src/auto/automation/retro_planner.py
+++ b/src/auto/automation/retro_planner.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+from openai import OpenAI
+
+from .plan_executor import ExecutionLogger, Plan, PlanManager, Step
+
+logger = logging.getLogger(__name__)
+
+
+class RetroPlanner:
+    """Simple planner that can regenerate a plan using an LLM."""
+
+    def __init__(self, llm_client: OpenAI, log_store: ExecutionLogger, pm: PlanManager) -> None:
+        self.llm = llm_client
+        self.log_store = log_store
+        self.pm = pm
+
+    def _build_prompt(self, plan: Plan) -> str:
+        recent = "\n".join(
+            f"{e['timestamp']}: {e['description']} -> {e['status']}"
+            for e in self.log_store.events[-10:]
+        )
+        step_text = "\n".join(s.description for s in plan.steps)
+        return (
+            "The automation has stalled or failed.\n"
+            f"Objective: {plan.objective}\n"
+            "Current steps:\n" + step_text + "\n"
+            "Recent events:\n" + recent + "\n"
+            "Provide a revised numbered list of steps."\
+        )
+
+    def replan(self, plan: Plan) -> Plan:
+        prompt = self._build_prompt(plan)
+        try:
+            response = self.llm.complete(prompt)
+        except Exception as exc:
+            logger.warning("LLM replanning failed: %s", exc)
+            return plan
+
+        lines = [l.strip() for l in response.splitlines() if l.strip()]
+        new_steps = [Step(id=i, description=line) for i, line in enumerate(lines, 1)]
+        new_plan = Plan(objective=plan.objective, steps=new_steps)
+        self.pm.save(new_plan)
+        logger.info("Generated revised plan with %d steps", len(new_steps))
+        return new_plan

--- a/src/auto/automation/supervisor.py
+++ b/src/auto/automation/supervisor.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+
+from openai import OpenAI
+
+from .plan_executor import (
+    ExecutionLogger,
+    MemoryModule,
+    PlanManager,
+)
+from .retro_planner import RetroPlanner
+
+logger = logging.getLogger(__name__)
+
+# Supervisory timing constants
+CHECK_INTERVAL = timedelta(minutes=5)
+MAX_STALL = timedelta(minutes=2)
+MAX_FAILURES = 3
+
+
+def supervise_loop() -> None:
+    """Monitor automation progress and trigger replanning when needed."""
+    pm = PlanManager("plan.json")
+    el = ExecutionLogger("execution_log.json")
+    mm = MemoryModule("memory.json")
+    rp = RetroPlanner(llm_client=OpenAI(), log_store=el, pm=pm)
+
+    last_check = datetime.min.replace(tzinfo=timezone.utc)
+
+    while True:
+        now = datetime.now(timezone.utc)
+        if now - last_check < CHECK_INTERVAL:
+            time.sleep(30)
+            continue
+        last_check = now
+
+        plan = pm.load()
+        events = el.events
+        last_event = events[-1] if events else None
+
+        # 1) Time-based stall
+        if last_event and (
+            now - datetime.fromisoformat(last_event["timestamp"]) > MAX_STALL
+        ):
+            reason = "stall detected"
+        # 2) Failure-based trigger
+        elif (
+            mm.memory["step_stats"].get(str(plan.steps[0].id), {}).get("failed", 0)
+            >= MAX_FAILURES
+        ):
+            reason = "too many failures"
+        else:
+            reason = None
+
+        if reason:
+            logger.info("[Supervisor] Triggering replan: %s", reason)
+            plan = rp.replan(plan)
+        
+        time.sleep(1)


### PR DESCRIPTION
## Summary
- introduce automation supervisor to detect stalls and failures
- add a RetroPlanner helper used by the supervisor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a96a9c154832abd052702a713f256