### PR TITLE
Add file-based workflow state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 # Editor/IDE
 .vscode/
 .idea/
+workflow/

--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ Regenerate them with:
 python -c 'from auto.plan.parser import parse_plan; parse_plan("PLAN.md")'
 ```
 
+## Workflow automation
+
+The automation workflow controls Safari to open Codex tasks and merge
+pull requests. State is stored as JSON files under the ``workflow/``
+directory with one file per workflow ID. Steps progress through
+``FETCH_DOM``, ``PARSE_TASKS``, ``OPEN_PR`` and ``MERGE_PR``. Run the
+next step with:
+
+```bash
+python -m auto.cli automation execute-workflow
+```
+
 ## Running tests
 
 Before running tests, install the project dependencies. The

--- a/src/auto/automation/workflow.py
+++ b/src/auto/automation/workflow.py
@@ -1,0 +1,78 @@
+"""Simple GitHub pull request workflow automation."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any, Dict
+
+from ..html_helpers import fetch_dom
+from ..html_utils import extract_links_with_green_span, parse_codex_tasks
+from pathlib import Path
+
+from .safari import SafariController
+
+
+class WorkflowState(str, Enum):
+    FETCH_DOM = "FETCH_DOM"
+    PARSE_TASKS = "PARSE_TASKS"
+    OPEN_PR = "OPEN_PR"
+    MERGE_PR = "MERGE_PR"
+
+
+WORKFLOW_DIR = Path("workflow")
+
+
+def _load_payload(path: Path) -> Dict[str, Any]:
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:
+            pass
+    return {}
+
+
+def _save_payload(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _run_state(payload: Dict[str, Any], controller: SafariController) -> WorkflowState:
+    state = WorkflowState(payload.get("state", WorkflowState.FETCH_DOM))
+
+    if state == WorkflowState.FETCH_DOM:
+        dom = fetch_dom()
+        payload["dom"] = dom
+        next_state = WorkflowState.PARSE_TASKS
+
+    elif state == WorkflowState.PARSE_TASKS:
+        dom = payload.get("dom", "")
+        payload["tasks"] = parse_codex_tasks(dom)
+        links = extract_links_with_green_span(dom)
+        payload["pr_url"] = links[0] if links else None
+        next_state = WorkflowState.OPEN_PR
+
+    elif state == WorkflowState.OPEN_PR:
+        pr_url = payload.get("pr_url")
+        if pr_url:
+            controller.open(pr_url)
+        next_state = WorkflowState.MERGE_PR
+
+    else:  # MERGE_PR
+        controller.run_js("document.querySelector('button.js-merge-branch')?.click();")
+        next_state = WorkflowState.FETCH_DOM
+
+    payload["state"] = next_state.value
+    return next_state
+
+
+def execute(workflow_id: str = "default") -> WorkflowState:
+    """Execute the next step for ``workflow_id``."""
+
+    path = WORKFLOW_DIR / f"{workflow_id}.json"
+    payload = _load_payload(path)
+    controller = SafariController()
+    next_state = _run_state(payload, controller)
+    payload["state"] = next_state.value
+    _save_payload(path, payload)
+    return next_state

--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -16,6 +16,7 @@ from auto.cli.helpers import (
 from auto.html_helpers import fetch_dom as fetch_dom_html, count_link_states
 from auto.html_utils import extract_links_with_green_span, parse_codex_tasks
 from auto.automation.safari import SafariController
+from auto.automation.workflow import execute
 
 app = typer.Typer(help="Automation commands")
 
@@ -34,9 +35,7 @@ def chat(
     lm = dspy.LM(model=model, api_base=api_base, api_key="", model_type=model_type)
     dspy.configure(lm=lm)
 
-    default_question = (
-        "What is the typical silica (SiO₂) content in standard soda-lime glass, and how is it manufactured?"
-    )
+    default_question = "What is the typical silica (SiO₂) content in standard soda-lime glass, and how is it manufactured?"
     prompt = message or default_question
     response = dspy.chat(prompt)
     print(response)
@@ -202,3 +201,10 @@ def github_bot(codex_url: str = "https://chatgpt.com/codex") -> None:
     else:
         _slow_print("Failed to click Open button")
 
+
+@app.command()
+def execute_workflow(workflow_id: str = "default") -> None:
+    """Execute the next workflow step."""
+
+    state = execute(workflow_id)
+    print(f"Workflow state: {state.value}")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,58 @@
+import json
+
+from auto.automation import workflow
+
+
+class DummyController:
+    def __init__(self):
+        self.opened = []
+        self.js = []
+
+    def open(self, url):
+        self.opened.append(url)
+        return "OK"
+
+    def run_js(self, code):
+        self.js.append(code)
+        return "OK"
+
+
+def test_workflow_progress(monkeypatch, tmp_path):
+    monkeypatch.setattr(workflow, "SafariController", DummyController)
+    monkeypatch.setattr(workflow, "fetch_dom", lambda: "<html></html>")
+    monkeypatch.setattr(
+        workflow, "parse_codex_tasks", lambda html: [{"status": "Open"}]
+    )
+    monkeypatch.setattr(
+        workflow,
+        "extract_links_with_green_span",
+        lambda html: ["https://github.com/pull/1"],
+    )
+
+    monkeypatch.setattr(workflow, "WORKFLOW_DIR", tmp_path)
+
+    # first run creates the state file and fetches DOM
+    state = workflow.execute("test")
+    assert state == workflow.WorkflowState.PARSE_TASKS
+    data = json.loads((tmp_path / "test.json").read_text())
+    assert data["state"] == "PARSE_TASKS"
+    assert "dom" in data
+
+    # second run parses tasks
+    state = workflow.execute("test")
+    assert state == workflow.WorkflowState.OPEN_PR
+    data = json.loads((tmp_path / "test.json").read_text())
+    assert data["state"] == "OPEN_PR"
+    assert data["pr_url"] == "https://github.com/pull/1"
+
+    # third run opens PR
+    state = workflow.execute("test")
+    assert state == workflow.WorkflowState.MERGE_PR
+    data = json.loads((tmp_path / "test.json").read_text())
+    assert data["state"] == "MERGE_PR"
+
+    # fourth run merges and cycles back to fetch
+    state = workflow.execute("test")
+    assert state == workflow.WorkflowState.FETCH_DOM
+    data = json.loads((tmp_path / "test.json").read_text())
+    assert data["state"] == "FETCH_DOM"


### PR DESCRIPTION
## Summary
- remove database field for workflow state
- store workflow progress in JSON files
- update README on workflow usage
- ignore local workflow files
- test file-based workflow logic

## Testing
- `pre-commit run --files .gitignore README.md src/auto/automation/workflow.py src/auto/models.py tests/test_workflow.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a6f1fa9c4832aaa1cc2d8ffea78f5