### PR TITLE
Add cassette snapshot support to plan executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ python -m auto.automation.plan_executor plan.json
 ```
 
 DOM snapshots and backups are written alongside the plan so failures can be
-inspected or rolled back.
+inspected or rolled back. Each HTML snapshot is also copied to a `cassettes/`
+subdirectory which allows tests to replay DOM content without a live network.
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- copy DOM snapshots to a `cassettes/` folder for test playback
- mention cassette snapshots in README

## Testing
- `pre-commit run --files src/auto/automation/plan_executor.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687baad33eec832aa3dc228e5339873b