### PR TITLE
Refactor Scheduler initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ migrations.
 ## Scheduler
 
 The background scheduler is started automatically during application
-startup.  The FastAPI lifespan in `src/auto/main.py` calls
-`scheduler.start()` which continuously executes entries from the
-`tasks` table.  Tasks have a ``type`` and optional JSON payload.  Current
+startup.  The FastAPI lifespan in `src/auto/main.py` creates a
+`Scheduler` instance and calls its `start()` method, which continuously
+executes entries from the `tasks` table.  Tasks have a ``type`` and
+optional JSON payload.  Current
 types are ``publish_post`` and ``ingest_feed``.  You can also run the
 scheduler on its own:
 

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -3,7 +3,8 @@ from fastapi import FastAPI, HTTPException
 import asyncio
 from contextlib import asynccontextmanager
 from .feeds.ingestion import init_db, run_ingest
-from . import scheduler, configure_logging
+from .scheduler import Scheduler
+from . import configure_logging
 from .metrics import router as metrics_router
 import logging
 
@@ -14,11 +15,12 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     configure_logging()
     init_db()
-    await scheduler.start()
+    sched = Scheduler()
+    await sched.start()
     try:
         yield
     finally:
-        await scheduler.stop()
+        await sched.stop()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -140,7 +140,7 @@ async def run_scheduler():
 
 
 class Scheduler:
-    """Manage the background scheduler task without using module-level globals."""
+    """Manage the background scheduler task without relying on globals."""
 
     def __init__(self) -> None:
         self._task: Optional[asyncio.Task] = None
@@ -175,19 +175,6 @@ class Scheduler:
                 pass
             self._task = None
 
-
-# provide a default scheduler instance for backwards compatibility
-default_scheduler = Scheduler()
-
-
-async def start() -> Optional[asyncio.Task]:
-    """Start the default background scheduler loop."""
-    return await default_scheduler.start()
-
-
-async def stop() -> None:
-    """Stop the default background scheduler loop."""
-    await default_scheduler.stop()
 
 
 def main():


### PR DESCRIPTION
## Summary
- create a new `Scheduler` instance inside the FastAPI lifespan
- remove module-level `default_scheduler` globals
- update README docs for updated scheduler setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bafbd4e6c832a97bc203d909b3743