### PR TITLE
Introduce PeriodicWorker helper

### DIFF
--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -15,6 +15,7 @@ from .db import SessionLocal, get_engine
 from .socials.base import SocialPlugin
 from .socials.mastodon_client import MastodonClient
 from .metrics import POSTS_PUBLISHED, POSTS_FAILED
+from .utils.periodic import PeriodicWorker
 from .config import (
     get_poll_interval,
     get_post_delay,
@@ -133,21 +134,30 @@ async def process_pending(max_attempts: Optional[int] = None):
                 session.commit()
 
 
-async def run_scheduler():
-    while True:
-        await process_pending()
-        await asyncio.sleep(get_poll_interval())
+async def _scheduler_iteration() -> None:
+    await process_pending()
+
+
+async def run_scheduler() -> None:
+    """Run the scheduler loop until cancelled."""
+    worker = PeriodicWorker(_scheduler_iteration, get_poll_interval)
+    await worker.start()
+    try:
+        if worker.task:
+            await worker.task
+    finally:
+        await worker.stop()
 
 
 class Scheduler:
     """Manage the background scheduler task without using module-level globals."""
 
     def __init__(self) -> None:
-        self._task: Optional[asyncio.Task] = None
+        self._worker = PeriodicWorker(_scheduler_iteration, get_poll_interval)
 
     async def start(self) -> Optional[asyncio.Task]:
         """Start the background scheduler loop."""
-        if self._task is None or self._task.done():
+        if self._worker.task is None or self._worker.task.done():
             from sqlalchemy import inspect
 
             inspector = inspect(get_engine())
@@ -162,18 +172,12 @@ class Scheduler:
                 ingest_scheduler.ensure_initial_task(session)
                 session.commit()
 
-            self._task = asyncio.create_task(run_scheduler())
-        return self._task
+            await self._worker.start()
+        return self._worker.task
 
     async def stop(self) -> None:
         """Stop the background scheduler loop."""
-        if self._task:
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
-            self._task = None
+        await self._worker.stop()
 
 
 # provide a default scheduler instance for backwards compatibility

--- a/src/auto/utils/periodic.py
+++ b/src/auto/utils/periodic.py
@@ -1,0 +1,49 @@
+import asyncio
+from typing import Any, Awaitable, Callable, Optional
+
+
+class PeriodicWorker:
+    """Run a callable repeatedly in an ``asyncio`` task."""
+
+    def __init__(
+        self,
+        func: Callable[[], Awaitable[Any] | Any],
+        interval: float | Callable[[], float],
+    ) -> None:
+        self._func = func
+        self._interval = interval
+        self._task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
+
+    @property
+    def task(self) -> Optional[asyncio.Task]:
+        """Return the underlying asyncio task if running."""
+        return self._task
+
+    async def _run(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                if asyncio.iscoroutinefunction(self._func):
+                    await self._func()
+                else:
+                    await asyncio.to_thread(self._func)
+                wait = self._interval() if callable(self._interval) else self._interval
+                await asyncio.sleep(wait)
+        except asyncio.CancelledError:
+            pass
+
+    async def start(self) -> Optional[asyncio.Task]:
+        if self._task is None or self._task.done():
+            self._stop_event.clear()
+            self._task = asyncio.create_task(self._run())
+        return self._task
+
+    async def stop(self) -> None:
+        if self._task:
+            self._stop_event.set()
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None

--- a/tests/test_periodic_worker.py
+++ b/tests/test_periodic_worker.py
@@ -1,0 +1,21 @@
+import asyncio
+from auto.utils.periodic import PeriodicWorker
+
+
+def test_periodic_worker_runs_and_stops():
+    counter = {"count": 0}
+
+    async def work():
+        counter["count"] += 1
+
+    worker = PeriodicWorker(work, 0.01)
+
+    async def run():
+        await worker.start()
+        await asyncio.sleep(0.03)
+        await worker.stop()
+
+    asyncio.run(run())
+
+    assert worker.task is None
+    assert counter["count"] >= 2

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,7 +4,7 @@ import json
 
 from auto.db import SessionLocal
 from auto.models import Post, PostStatus, Task
-from auto.scheduler import process_pending, PLUGINS
+from auto.scheduler import process_pending, PLUGINS, Scheduler
 from auto.metrics import POSTS_PUBLISHED, POSTS_FAILED
 
 
@@ -133,3 +133,19 @@ def test_publish_failure_metrics(test_db_engine, monkeypatch):
         t = session.get(Task, task_id)
         assert t.status == "completed"
     assert POSTS_FAILED.labels(network="mastodon")._value.get() == start + 1
+
+
+def test_scheduler_start_stop(test_db_engine, monkeypatch):
+    monkeypatch.setattr("auto.ingest_scheduler.ensure_initial_task", lambda s: None)
+    monkeypatch.setenv("SCHEDULER_POLL_INTERVAL", "0")
+
+    sched = Scheduler()
+
+    async def run():
+        task = await sched.start()
+        assert task is sched._worker.task
+        await asyncio.sleep(0.01)
+        await sched.stop()
+        assert sched._worker.task is None
+
+    asyncio.run(run())

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,0 +1,60 @@
+import asyncio
+from datetime import datetime, timezone, timedelta
+
+from auto.automation import supervisor
+
+
+class DummyPlan:
+    def __init__(self):
+        self.objective = "test"
+        self.steps = [type("Step", (), {"id": 1})()]
+
+
+class DummyPlanManager:
+    def load(self):
+        return DummyPlan()
+
+
+class DummyExecutionLogger:
+    def __init__(self):
+        self.events = []
+
+
+class DummyMemoryModule:
+    def __init__(self, failed=0):
+        self.memory = {"step_stats": {"1": {"failed": failed}}}
+
+
+class DummyRetroPlanner:
+    def __init__(self):
+        self.called = False
+
+    def replan(self, plan):
+        self.called = True
+        return plan
+
+
+def test_supervisor_start_stop(monkeypatch):
+    pm = DummyPlanManager()
+    el = DummyExecutionLogger()
+    mm = DummyMemoryModule(failed=5)
+    rp = DummyRetroPlanner()
+
+    monkeypatch.setattr(supervisor, "PlanManager", lambda *a, **k: pm)
+    monkeypatch.setattr(supervisor, "ExecutionLogger", lambda *a, **k: el)
+    monkeypatch.setattr(supervisor, "MemoryModule", lambda *a, **k: mm)
+    monkeypatch.setattr(supervisor, "RetroPlanner", lambda *a, **k: rp)
+    monkeypatch.setattr(supervisor, "OpenAI", lambda *a, **k: object())
+
+    sup = supervisor.Supervisor()
+    sup._last_check = datetime.now(timezone.utc) - supervisor.CHECK_INTERVAL - timedelta(seconds=1)
+
+    async def run():
+        await sup.start()
+        await asyncio.sleep(0.05)
+        await sup.stop()
+
+    asyncio.run(run())
+
+    assert sup._worker.task is None
+    assert rp.called


### PR DESCRIPTION
## Summary
- add `PeriodicWorker` helper for repeated async tasks
- refactor scheduler and supervisor loops to use the new helper
- add unit tests for `PeriodicWorker`, `Scheduler` and `Supervisor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bafb77ac0832a8c3ca4593b03cb8f