### PR TITLE
Add simple post creation form

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -115,3 +115,4 @@ wsproto==1.2.0
 xxhash==3.5.0
 yarl==1.20.1
 zipp==3.23.0
+python-multipart==0.0.9

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from .feeds.ingestion import init_db, run_ingest
 from . import scheduler, configure_logging
 from .metrics import router as metrics_router
+from .web_posts import router as posts_router
 import logging
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 app.include_router(metrics_router)
+app.include_router(posts_router)
 
 
 @app.post("/ingest")

--- a/src/auto/templates/create_post.html
+++ b/src/auto/templates/create_post.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Create Post</title>
+</head>
+<body>
+    <h1>Create Post</h1>
+    <form action="/posts" method="post">
+        <label>ID: <input type="text" name="id" required></label><br>
+        <label>Title: <input type="text" name="title" required></label><br>
+        <label>Link: <input type="text" name="link" required></label><br>
+        <label>Summary:<br><textarea name="summary" rows="4" cols="40"></textarea></label><br>
+        <label>Published: <input type="text" name="published"></label><br>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/src/auto/web_posts.py
+++ b/src/auto/web_posts.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from .db import SessionLocal
+from .models import Post
+
+
+TEMPLATES = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
+
+router = APIRouter()
+
+
+@router.get("/posts/new", response_class=HTMLResponse)
+async def new_post(request: Request) -> HTMLResponse:
+    """Render a simple form for creating posts."""
+    return TEMPLATES.TemplateResponse("create_post.html", {"request": request})
+
+
+@router.post("/posts")
+async def create_post(
+    id: str = Form(...),
+    title: str = Form(...),
+    link: str = Form(...),
+    summary: str = Form(""),
+    published: str = Form(""),
+) -> RedirectResponse:
+    """Save the submitted post data."""
+    post = Post(
+        id=id,
+        title=title,
+        link=link,
+        summary=summary,
+        published=published,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    with SessionLocal() as session:
+        session.add(post)
+        session.commit()
+    return RedirectResponse(url="/posts/new", status_code=303)

--- a/tests/test_post_form.py
+++ b/tests/test_post_form.py
@@ -1,0 +1,22 @@
+import auto.main as main
+from auto.db import SessionLocal
+from auto.models import Post
+from fastapi.testclient import TestClient
+
+
+def test_post_form_insert(test_db_engine):
+    with TestClient(main.app) as client:
+        resp = client.get("/posts/new")
+        assert resp.status_code == 200
+        assert "<form" in resp.text
+        data = {
+            "id": "test1",
+            "title": "Title",
+            "link": "http://example.com",
+            "summary": "",
+            "published": "",
+        }
+        resp = client.post("/posts", data=data, allow_redirects=False)
+        assert resp.status_code == 303
+    with SessionLocal() as session:
+        assert session.get(Post, "test1") is not None


### PR DESCRIPTION
## Summary
- provide HTML form and endpoint to create posts
- expose the post form routes in the main FastAPI app
- add requirement for python-multipart
- test the new form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687baf19ad04832a8b11882fd385fd1c