### PR TITLE
Fix Typer support for Python 3.13

### DIFF
--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 
+from typing import Optional
+
 import typer
 
 from auto.cli.helpers import (
@@ -22,7 +24,7 @@ app = typer.Typer(help="Automation commands")
 
 @app.command()
 def chat(
-    message: str | None = None,
+    message: Optional[str] = None,
     model: str = "gemma-3-27b-it-qat",
     api_base: str = "http://localhost:1234/v1",
     model_type: str = "chat",

--- a/src/auto/cli/publish.py
+++ b/src/auto/cli/publish.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 import typer
 from sqlalchemy import select, case
 
@@ -39,7 +41,7 @@ def list_posts() -> None:
 
 
 @app.command()
-def schedule(post_id: str, time: str, network: str | None = None) -> None:
+def schedule(post_id: str, time: str, network: Optional[str] = None) -> None:
     """Schedule a post for publishing."""
 
     scheduled_at = _parse_when(time)
@@ -95,7 +97,7 @@ def quick_post(network: str = "mastodon") -> None:
 
 
 @app.command()
-def trending_tags(limit: int = 10, instance: str | None = None, token: str | None = None) -> None:
+def trending_tags(limit: int = 10, instance: Optional[str] = None, token: Optional[str] = None) -> None:
     """Display trending tags from Mastodon."""
 
     from mastodon import Mastodon

--- a/tests/test_post_form.py
+++ b/tests/test_post_form.py
@@ -16,7 +16,7 @@ def test_post_form_insert(test_db_engine):
             "summary": "",
             "published": "",
         }
-        resp = client.post("/posts", data=data, allow_redirects=False)
+        resp = client.post("/posts", data=data, follow_redirects=False)
         assert resp.status_code == 303
     with SessionLocal() as session:
         assert session.get(Post, "test1") is not None


### PR DESCRIPTION
## Summary
- avoid PEP 604 unions in CLI signatures
- update test to use `follow_redirects`

## Testing
- `invoke uv --host 127.0.0.1 --port 8000 --no-reload`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb0f8d300832a878e9a537459bb86