### PR TITLE
Add pytest-recording to deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
-  "pytest",
-  "pytest-cov",
-  "ruff",
+  dev = [
+    "pytest",
+    "pytest-cov",
+    "pytest-recording",
+    "ruff",
   "black",
   "pre-commit",
   "invoke",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ packaging==25.0
 prometheus-client==0.22.1
 pytest==8.4.1
 pytest-cov==6.2.1
+pytest-recording==0.13.4
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 selenium==4.34.2


### PR DESCRIPTION
## Summary
- include `pytest-recording` in dev dependencies and pinned requirements

## Testing
- `pre-commit run --files pyproject.toml requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687bb61e64a8832a81a37bf527a719d4