### PR TITLE
Refactor plan executor modules

### DIFF
--- a/src/auto/automation/retro_planner.py
+++ b/src/auto/automation/retro_planner.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 from openai import OpenAI
 
-from .plan_executor import ExecutionLogger, Plan, PlanManager, Step
+from ..plan.logging import ExecutionLogger
+from ..plan.types import Plan, PlanManager, Step
 
 logger = logging.getLogger(__name__)
 

--- a/src/auto/automation/supervisor.py
+++ b/src/auto/automation/supervisor.py
@@ -7,11 +7,8 @@ from datetime import datetime, timedelta, timezone
 from openai import OpenAI
 from ..utils.periodic import PeriodicWorker
 
-from .plan_executor import (
-    ExecutionLogger,
-    MemoryModule,
-    PlanManager,
-)
+from ..plan.logging import ExecutionLogger, MemoryModule
+from ..plan.types import PlanManager
 from .retro_planner import RetroPlanner
 
 logger = logging.getLogger(__name__)

--- a/src/auto/plan/logging.py
+++ b/src/auto/plan/logging.py
@@ -1,0 +1,61 @@
+"""Logging utilities for plan execution."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+def configure_logging() -> None:
+    """Initialize logging when the plan executor starts."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        filename="agent.log",
+        filemode="a",
+    )
+
+
+class ExecutionLogger:
+    """Persist structured events from plan execution."""
+
+    def __init__(self, path: str = "execution_log.json") -> None:
+        self.path = path
+        try:
+            with open(self.path, "r") as f:
+                self.events = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            self.events = []
+
+    def log_event(self, event: Dict) -> None:
+        self.events.append(event)
+        with open(self.path, "w") as f:
+            json.dump(self.events, f, indent=2)
+        logger.info("Logged event: %s", event)
+
+
+class MemoryModule:
+    """Track step statistics across runs."""
+
+    def __init__(self, path: str = "memory.json") -> None:
+        self.path = path
+        try:
+            with open(self.path, "r") as f:
+                self.memory = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            self.memory = {"step_stats": {}}
+
+    def record_event(self, event: Dict) -> None:
+        sid = str(event["step_id"])
+        stats = self.memory["step_stats"].setdefault(sid, {"success": 0, "failed": 0, "abandoned": 0})
+        status = event.get("status")
+        if status in stats:
+            stats[status] += 1
+        with open(self.path, "w") as f:
+            json.dump(self.memory, f, indent=2)
+        logger.info("Updated memory for step %s: %s", sid, stats)
+

--- a/src/auto/plan/types.py
+++ b/src/auto/plan/types.py
@@ -1,0 +1,115 @@
+"""Data structures and helpers for automation plans."""
+
+from __future__ import annotations
+
+import json
+import glob
+import shutil
+import subprocess
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Dict, Any
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Step:
+    """Represents one atomic automation step."""
+
+    id: int
+    type: Optional[str] = None
+    description: Optional[str] = None
+    url: Optional[str] = None
+    selector: Optional[str] = None
+    prompt_template: Optional[str] = None
+    store_as: Optional[str] = None
+    status: str = "pending"  # pending | success | failed | abandoned
+    result: Optional[str] = None  # log of what happened
+    dom_snapshot: Optional[str] = None  # path to saved DOM snapshot
+    pre_conditions: List[str] = field(default_factory=list)
+    post_conditions: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Plan:
+    objective: str
+    steps: List[Step]
+
+
+class PlanManager:
+    """Handle reading, writing and backing up plan files."""
+
+    def __init__(self, path: str, backup_dir: str = "backups", work_path: Optional[str] = None) -> None:
+        self.src_path = path
+        suffix = Path(path).suffix
+        self.path = work_path or f"{Path(path).stem}_work{suffix}"
+        self.backup_dir = Path(backup_dir)
+        self._ensure_working_copy()
+
+    def _ensure_working_copy(self) -> None:
+        if not Path(self.path).exists() and Path(self.src_path).exists():
+            shutil.copy(self.src_path, self.path)
+            logger.info("Copied plan %s -> %s", self.src_path, self.path)
+
+    def load(self) -> Plan:
+        self._ensure_working_copy()
+        data = json.load(open(self.path))
+        steps = [Step(**s) for s in data.get("steps", [])]
+        plan = Plan(objective=data.get("objective", ""), steps=steps)
+        logger.info("Loaded plan: %s with %d steps", plan.objective, len(steps))
+        return plan
+
+    def save(self, plan: Plan) -> None:
+        with open(self.path, "w") as f:
+            json.dump({"objective": plan.objective, "steps": [asdict(s) for s in plan.steps]}, f, indent=2)
+        logger.info("Saved plan to %s", self.path)
+        commit_file(self.path, f"Update plan after changes at {datetime.now(timezone.utc).isoformat()}")
+
+    def reset(self) -> None:
+        artifacts = [self.path, "execution_log.json", "memory.json"]
+        for art in artifacts:
+            try:
+                Path(art).unlink(missing_ok=True)
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                logger.warning("Failed to delete %s: %s", art, exc)
+        for html in glob.glob("dom_step_*.html"):
+            try:
+                Path(html).unlink(missing_ok=True)
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                logger.warning("Failed to delete DOM snapshot %s: %s", html, exc)
+        if self.backup_dir.is_dir():
+            shutil.rmtree(self.backup_dir, ignore_errors=True)
+        logger.info("Reset plan state and removed artifacts")
+
+    def backup(self) -> None:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        dest = self.backup_dir / f"plan_{timestamp}.json"
+        self.backup_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(self.path, dest)
+        logger.info("Backup of plan saved to %s", dest)
+
+    def restore(self, step_id: int) -> Plan:
+        plan = self.load()
+        for step in plan.steps:
+            if step.id >= step_id:
+                step.status = "pending"
+                step.result = None
+                step.dom_snapshot = None
+        self.save(plan)
+        logger.info("Restored plan to step %d", step_id)
+        return plan
+
+
+def commit_file(path: str, message: str) -> None:
+    """Commit a file to git if possible."""
+    try:
+        subprocess.run(["git", "add", path], check=True)
+        subprocess.run(["git", "commit", "-m", message], check=True)
+        logger.info("Committed %s: %s", path, message)
+    except Exception as e:  # pragma: no cover - git may not be available
+        logger.warning("Git commit failed for %s: %s", path, e)
+


### PR DESCRIPTION
## Summary
- move plan dataclasses and helpers to `plan/types.py`
- centralize execution logging in `plan/logging.py`
- simplify `plan_executor.py` to orchestrate using new modules
- adjust supervisor and retro planner imports
- add namespace package for `auto.plan`

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest-recording`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb634754c832a8f8952035027257d