### PR TITLE
Add git cleanup task

### DIFF
--- a/src/auto/cli/maintenance.py
+++ b/src/auto/cli/maintenance.py
@@ -50,3 +50,11 @@ def update_deps(freeze: bool = False) -> None:
 
     update_dependencies(freeze=freeze)
 
+
+
+@app.command()
+def cleanup_branches(remote: str = "origin", main: str = "main") -> None:
+    """Delete branches merged into ``main`` locally and on ``remote``."""
+    from auto.git_utils import cleanup_merged_branches
+
+    cleanup_merged_branches(remote=remote, main=main)

--- a/src/auto/git_utils.py
+++ b/src/auto/git_utils.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Git repository maintenance helpers."""
+
+import subprocess
+from typing import List
+
+
+
+def _run_git(cmd: List[str]) -> subprocess.CompletedProcess:
+    """Run a git command and return the completed process."""
+    return subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+
+def cleanup_merged_branches(remote: str = "origin", main: str = "main") -> None:
+    """Remove branches merged into ``main`` locally and on ``remote``."""
+    subprocess.run(["git", "fetch", "--prune", remote], check=True)
+    subprocess.run(["git", "checkout", main], check=True)
+    subprocess.run(["git", "pull", remote, main], check=True)
+
+    local = _run_git(["git", "branch", "--merged"]).stdout.splitlines()
+    to_delete = []
+    for line in local:
+        branch = line.replace("*", "").strip()
+        if branch and branch not in (main, "develop"):
+            to_delete.append(branch)
+
+    for br in to_delete:
+        subprocess.run(["git", "branch", "-d", br], check=True)
+
+    merged = _run_git(["git", "branch", "-r", "--merged", f"{remote}/{main}"]).stdout.splitlines()
+    prefix = f"{remote}/"
+    remote_delete = []
+    for line in merged:
+        line = line.strip()
+        if not line.startswith(prefix):
+            continue
+        br = line[len(prefix):]
+        if br not in (main, "develop", "HEAD"):
+            remote_delete.append(br)
+
+    for br in remote_delete:
+        subprocess.run(["git", "push", remote, "--delete", br], check=True)
+

--- a/tasks.py
+++ b/tasks.py
@@ -63,6 +63,15 @@ def update_deps(c, freeze=False):
 
 
 @task
+def cleanup_branches(c, remote="origin", main="main"):
+    """Delete branches merged into main locally and on the remote."""
+    c.run(
+        f"python -m auto.cli maintenance cleanup-branches --remote {remote} --main {main}",
+        pty=True,
+    )
+
+
+@task
 def parse_plan(c):
     """Parse PLAN.md into task files."""
     c.run(

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,0 +1,22 @@
+from auto.git_utils import cleanup_merged_branches
+import subprocess
+
+
+def test_cleanup_branches(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, capture_output=False, text=False, check=False):
+        calls.append(cmd)
+        from subprocess import CompletedProcess
+        if cmd[:3] == ["git", "branch", "--merged"]:
+            return CompletedProcess(cmd, 0, stdout="  main\n  feature\n")
+        if cmd[:4] == ["git", "branch", "-r", "--merged"]:
+            return CompletedProcess(cmd, 0, stdout="  origin/main\n  origin/old\n")
+        return CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cleanup_merged_branches()
+
+    assert ["git", "branch", "-d", "feature"] in calls
+    assert ["git", "push", "origin", "--delete", "old"] in calls


### PR DESCRIPTION
## Summary
- implement `cleanup_merged_branches` helper to delete merged branches
- expose a `cleanup-branches` command under the maintenance CLI
- add a matching Invoke task
- unit test the git cleanup logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb93bc428832aa55f77eb990ae5df