### PR TITLE
Add metrics task

### DIFF
--- a/src/auto/cli/maintenance.py
+++ b/src/auto/cli/maintenance.py
@@ -51,10 +51,17 @@ def update_deps(freeze: bool = False) -> None:
     update_dependencies(freeze=freeze)
 
 
-
 @app.command()
 def cleanup_branches(remote: str = "origin", main: str = "main") -> None:
     """Delete branches merged into ``main`` locally and on ``remote``."""
     from auto.git_utils import cleanup_merged_branches
 
     cleanup_merged_branches(remote=remote, main=main)
+
+
+@app.command()
+def metrics(host: str = "localhost", port: int = 8000) -> None:
+    """Output Prometheus metrics from the running server."""
+
+    url = f"http://{host}:{port}/metrics"
+    subprocess.run(["curl", "-s", url], check=True)

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -13,6 +13,9 @@ from .models import PostStatus, Post, PostPreview, Task
 
 from .db import SessionLocal, get_engine
 from .socials.registry import get_plugin
+
+# Temporary alias for tests using the old PLUGINS mapping
+from .socials.registry import _PLUGINS as PLUGINS
 from .metrics import POSTS_PUBLISHED, POSTS_FAILED
 from .utils.periodic import PeriodicWorker
 from .config import (
@@ -172,7 +175,6 @@ class Scheduler:
     async def stop(self) -> None:
         """Stop the background scheduler loop."""
         await self._worker.stop()
-
 
 
 def main():

--- a/tasks.py
+++ b/tasks.py
@@ -72,6 +72,15 @@ def cleanup_branches(c, remote="origin", main="main"):
 
 
 @task
+def metrics(c, host="localhost", port=8000):
+    """Output Prometheus metrics from the running server."""
+    c.run(
+        f"python -m auto.cli maintenance metrics --host {host} --port {port}",
+        pty=True,
+    )
+
+
+@task
 def parse_plan(c):
     """Parse PLAN.md into task files."""
     c.run(


### PR DESCRIPTION
## Summary
- fetch `/metrics` via a new `metrics` command
- wrap the new command in an invoke task
- expose PLUGINS alias for old tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc3003db0832a879b7c8e5c54d777