### PR TITLE
Add posts collected metric

### DIFF
--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,11 +1,19 @@
 import auto.main as main
-from auto.metrics import POSTS_PUBLISHED
+from auto.metrics import POSTS_PUBLISHED, POSTS_COLLECTED
+from auto.db import SessionLocal
+from auto.models import Post
 from fastapi.testclient import TestClient
 
 
-def test_metrics_endpoint():
+def test_metrics_endpoint(test_db_engine):
+    with SessionLocal() as session:
+        session.add(Post(id="1", title="t1", link="http://1"))
+        session.add(Post(id="2", title="t2", link="http://2"))
+        session.commit()
+
     POSTS_PUBLISHED.labels(network="mastodon").inc()
     with TestClient(main.app) as client:
         resp = client.get("/metrics")
         assert resp.status_code == 200
         assert "posts_published_total" in resp.text
+    assert POSTS_COLLECTED._value.get() == 2


### PR DESCRIPTION
## Summary
- report number of collected posts in Prometheus metrics
- test the post count metric via `/metrics`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc94d1020832a92b63557a4f9eb9b