### PR TITLE
Fix cleanup branches error

### DIFF
--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -11,7 +11,11 @@ def test_cleanup_branches(monkeypatch):
         if cmd[:3] == ["git", "branch", "--merged"]:
             return CompletedProcess(cmd, 0, stdout="  main\n  feature\n")
         if cmd[:4] == ["git", "branch", "-r", "--merged"]:
-            return CompletedProcess(cmd, 0, stdout="  origin/main\n  origin/old\n")
+            return CompletedProcess(
+                cmd,
+                0,
+                stdout="  origin/main\n  origin/HEAD -> origin/main\n  origin/old\n",
+            )
         return CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary
- ignore symbolic HEAD refs when pruning merged branches
- report push deletion errors rather than failing
- test cleanup with HEAD lines

## Testing
- `invoke tests`

------
https://chatgpt.com/codex/tasks/task_e_687bd3ee4004832a8afc9b9c32c26332