### PR TITLE
Move plan tasks into TODO list

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,12 @@
 
 ## High Priority
 
+- Refactor `src/auto/automation/plan_executor.py` into focused submodules so types live in `plan/types.py` and logging helpers in `plan/logging.py`.
+- Remove the module-level scheduler globals and create `Scheduler` instances in `main.py`.
+
 ## Medium Priority
 - Integrate the Medium automation client so posts can also be published there.
+- Move plugin registration to `src/auto/socials/registry.py` and document how to write a plugin with an example `medium_client.py`.
 
 ## Low Priority
 - Expand social network support beyond Mastodon.
@@ -15,7 +19,7 @@
 - AppleScript automation assumes the "Google" Mail account, which is brittle.
 
 ## DRY
-- The scheduler classes share very similar start/stop loops.
+- Create a `PeriodicWorker` helper in `src/auto/utils/periodic.py` and use it in the scheduler and supervisor loops.
 
 ## BUGS
 - `schedule()` stores naive datetimes when no timezone is supplied, leading to
@@ -24,3 +28,8 @@
 ## RECS
 - Add a CLI wrapper for common tasks like listing posts or scheduling to reduce reliance on Invoke.
 - Package the project so tests no longer modify `sys.path` directly.
+- Provide invoke tasks `install_hooks`, `parse_plan`, and `setup` for routine development.
+- Centralize configuration with a `Settings` class that loads environment variables at runtime.
+- Add a GitHub Actions workflow for tests, linting, and formatting.
+- Use context managers everywhere `SessionLocal()` is called.
+- Add a simple `mypy` configuration and start annotating modules.


### PR DESCRIPTION
## Summary
- migrate planned tasks from `PLAN.md` to `TODO.md`
- remove obsolete `PLAN.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687baaf6a42c832a9ab34d1307b1f705