### PR TITLE
Improve scheduler output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ scheduler on its own:
 ```bash
 python -m auto.scheduler
 ```
+The command logs when the loop starts and stops so you know it's running.
 
 ## Ingesting Substack posts
 

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -137,13 +137,20 @@ async def _scheduler_iteration() -> None:
 
 async def run_scheduler() -> None:
     """Run the scheduler loop until cancelled."""
-    worker = PeriodicWorker(_scheduler_iteration, get_poll_interval)
-    await worker.start()
+    from . import configure_logging
+
+    configure_logging()
+    sched = Scheduler()
+    task = await sched.start()
+    if task is None:
+        return
+
+    logger.info("Scheduler started; press Ctrl+C to exit")
     try:
-        if worker.task:
-            await worker.task
+        await task
     finally:
-        await worker.stop()
+        await sched.stop()
+        logger.info("Scheduler stopped")
 
 
 class Scheduler:


### PR DESCRIPTION
## Summary
- make `python -m auto.scheduler` configure logging and print status messages
- mention scheduler messages in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd39b076c832a878c1ddf599860c7