### PR TITLE
Add mastodon sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ python -m auto.cli publish edit-preview --post-id <id> --network mastodon
 
 `generate-preview` uses a local LLM when available and falls back to a simple template. Previews are only created when the post has been scheduled.
 
+## Syncing Mastodon posts
+
+If you previously published to Mastodon outside of Auto, run the sync command to
+mark matching posts as published:
+
+```bash
+python -m auto.cli publish sync-mastodon-posts
+```
+
+Set `MASTODON_SYNC_DEBUG=1` to print the fetched statuses while syncing.
+
 ## Writing social network plugins
 
 Plugins implement the `SocialPlugin` protocol defined in `src/auto/socials/base.py`. Create a new module under `src/auto/socials/` with `post()` and `fetch_metrics()` methods and register an instance using `register_plugin()` from `src/auto/socials/registry.py`. The `network` attribute of the plugin is used to look it up when publishing. See `medium_client.py` for a minimal example.

--- a/src/auto/cli/publish.py
+++ b/src/auto/cli/publish.py
@@ -199,3 +199,15 @@ def edit_preview(post_id: str, network: str = "mastodon") -> None:
         session.commit()
     print("Preview updated")
 
+@app.command()
+def sync_mastodon_posts() -> None:
+    """Mark posts as published if they already appear on Mastodon."""
+    import asyncio
+    from auto.db import SessionLocal
+    from auto.models import Task
+    from auto.mastodon_sync import handle_sync_mastodon_posts
+
+    with SessionLocal() as session:
+        task = Task(type="sync_mastodon_posts")
+        asyncio.run(handle_sync_mastodon_posts(task, session))
+

--- a/tasks.py
+++ b/tasks.py
@@ -56,6 +56,12 @@ def edit_preview(c, post_id, network="mastodon"):
 
 
 @task
+def sync_mastodon_posts(c):
+    """Mark posts as published if they already appear on Mastodon."""
+    c.run("python -m auto.cli publish sync-mastodon-posts", pty=True)
+
+
+@task
 def update_deps(c, freeze=False):
     """Upgrade dependencies to their latest versions."""
     flag = "--freeze" if freeze else ""


### PR DESCRIPTION
## Summary
- provide a `sync_mastodon_posts` invoke task
- expose new command via `publish` CLI
- document how to sync existing Mastodon posts

## Testing
- `invoke --list`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd8533fc0832a92fc0d4bd5393c87