### PR TITLE
Implement mypy setup and annotations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,4 +32,3 @@
 - Centralize configuration with a `Settings` class that loads environment variables at runtime.
 - Add a GitHub Actions workflow for tests, linting, and formatting.
 - Use context managers everywhere `SessionLocal()` is called.
-- Add a simple `mypy` configuration and start annotating modules.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = true
+show_error_codes = true
+pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pytest-cov",
     "pytest-recording",
     "ruff",
+    "mypy",
   "black",
   "pre-commit",
   "invoke",

--- a/src/auto/db.py
+++ b/src/auto/db.py
@@ -1,14 +1,15 @@
 """Database utilities for creating engines and sessions."""
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import declarative_base, sessionmaker, Session
 
 from .config import get_database_url
 
-_engine = None
+_engine: Engine | None = None
 
 
-def get_engine():
+def get_engine() -> Engine:
     """Return a cached SQLAlchemy engine instance."""
     global _engine
     if _engine is None:
@@ -22,7 +23,7 @@ def get_engine():
     return _engine
 
 
-def SessionLocal():
+def SessionLocal() -> Session:
     """Return a new session bound to the engine from :func:`get_engine`."""
     Session = sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
     return Session()

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -9,7 +9,8 @@ from alembic import command
 from dateutil import parser
 from pathlib import Path
 
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 from ..db import SessionLocal
 
@@ -25,7 +26,12 @@ DB_PATH = str(BASE_DIR / "substack.db")
 ALEMBIC_INI = BASE_DIR / "alembic.ini"
 
 
-def _session_for_path(db_path: str, *, engine=None, session_factory=None):
+def _session_for_path(
+    db_path: str,
+    *,
+    engine: Engine | None = None,
+    session_factory: sessionmaker | None = None,
+) -> Session:
     """Return a SQLAlchemy session for the given database path or engine."""
     if session_factory is not None:
         return session_factory()
@@ -37,7 +43,12 @@ def _session_for_path(db_path: str, *, engine=None, session_factory=None):
     return Session()
 
 
-def init_db(db_path=DB_PATH, *, engine=None, session_factory=None):
+def init_db(
+    db_path: str = DB_PATH,
+    *,
+    engine: Engine | None = None,
+    session_factory: sessionmaker | None = None,
+) -> None:
     """Run database migrations to ensure the schema exists."""
     alembic_cfg = Config(str(ALEMBIC_INI))
 

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -42,7 +42,7 @@ def register_task_handler(
     return decorator
 
 
-async def _publish(status: PostStatus, session):
+async def _publish(status: PostStatus, session: Session) -> None:
     post = session.get(Post, status.post_id)
     if not post:
         logger.error("Post %s not found", status.post_id)
@@ -89,7 +89,7 @@ async def handle_publish_post(task: Task, session: Session) -> None:
     await _publish(status, session)
 
 
-async def process_pending(max_attempts: Optional[int] = None):
+async def process_pending(max_attempts: Optional[int] = None) -> None:
     """Fetch due tasks and dispatch them to registered handlers."""
     now = datetime.now(timezone.utc)
     if max_attempts is None:


### PR DESCRIPTION
## Summary
- add a basic mypy configuration file
- include mypy in dev dependencies
- annotate database helpers
- annotate ingestion and scheduler functions
- remove completed todo item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd9a42e7c832ab1f838617332b152