### PR TITLE
Add Mastodon trending tags invoke task

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ python -m auto.cli publish sync-mastodon-posts
 
 Set `MASTODON_SYNC_DEBUG=1` to print the fetched statuses while syncing.
 
+### Viewing trending tags
+
+Fetch the current trending tags from your Mastodon instance:
+
+```bash
+python -m auto.cli publish trending-tags --limit 10
+```
+
+Pass `--instance` and `--token` to override the defaults from the environment.
+
 ## Writing social network plugins
 
 Plugins implement the `SocialPlugin` protocol defined in `src/auto/socials/base.py`. Create a new module under `src/auto/socials/` with `post()` and `fetch_metrics()` methods and register an instance using `register_plugin()` from `src/auto/socials/registry.py`. The `network` attribute of the plugin is used to look it up when publishing. See `medium_client.py` for a minimal example.

--- a/tasks.py
+++ b/tasks.py
@@ -56,6 +56,17 @@ def edit_preview(c, post_id, network="mastodon"):
 
 
 @task
+def trending_tags(c, limit=10, instance=None, token=None):
+    """Display trending tags from Mastodon."""
+    cmd = f"python -m auto.cli publish trending-tags --limit {limit}"
+    if instance:
+        cmd += f" --instance {instance}"
+    if token:
+        cmd += f" --token {token}"
+    c.run(cmd, pty=True)
+
+
+@task
 def sync_mastodon_posts(c):
     """Mark posts as published if they already appear on Mastodon."""
     c.run("python -m auto.cli publish sync-mastodon-posts", pty=True)


### PR DESCRIPTION
## Summary
- expose trending tags as an Invoke task
- document how to view trending tags

## Testing
- `pre-commit run --files tasks.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdbba0ff8832abc193fcb9a441144