### PR TITLE
Implement Medium social plugin

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## High Priority
 
 ## Medium Priority
-- Integrate the Medium automation client so posts can also be published there.
 - Move plugin registration to `src/auto/socials/registry.py` and document how to write a plugin with an example `medium_client.py`.
 
 ## Low Priority

--- a/src/auto/socials/medium_client.py
+++ b/src/auto/socials/medium_client.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
+import asyncio
 import logging
 from typing import Dict
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
 
 from .base import SocialPlugin
 from .registry import register_plugin
@@ -8,13 +14,31 @@ logger = logging.getLogger(__name__)
 
 
 class MediumClient(SocialPlugin):
-    """Placeholder SocialPlugin implementation for Medium."""
+    """SocialPlugin implementation using the Selenium automation client."""
 
     network = "medium"
 
+    def __init__(self, driver: webdriver.Firefox | None = None) -> None:
+        self.driver = driver
+
     async def post(self, text: str, visibility: str = "draft") -> None:
-        logger.info("MediumClient.post called with %s", text)
-        # TODO: implement real posting logic
+        """Publish ``text`` as a new Medium draft."""
+
+        await asyncio.to_thread(self._post_sync, text, visibility)
+
+    def _post_sync(self, text: str, visibility: str) -> None:
+        from ..automation.medium import MediumClient as AutomationClient
+
+        driver = self.driver or webdriver.Firefox()
+        client = AutomationClient(driver=driver)
+        try:
+            client.login()
+            driver.get("https://medium.com/new-story")
+            body = driver.find_element(By.TAG_NAME, "body")
+            body.send_keys(text)
+            logger.info("Created Medium draft")
+        finally:
+            client.close()
 
     async def fetch_metrics(self, post_id: str) -> Dict[str, int]:
         logger.info("MediumClient.fetch_metrics called for %s", post_id)

--- a/tests/test_medium_social_plugin.py
+++ b/tests/test_medium_social_plugin.py
@@ -1,0 +1,16 @@
+from auto.socials.medium_client import MediumClient
+from tests.test_medium_client import DummyDriver
+import asyncio
+
+
+def test_medium_plugin_post(monkeypatch):
+    monkeypatch.setenv("MEDIUM_EMAIL", "user@example.com")
+    monkeypatch.setenv("MEDIUM_PASSWORD", "secret")
+    driver = DummyDriver()
+    plugin = MediumClient(driver=driver)
+    asyncio.run(plugin.post("hello"))
+    assert ("get", "https://medium.com/m/signin") in driver.calls
+    assert ("get", "https://medium.com/new-story") in driver.calls
+    assert ("send_keys", "email", "user@example.com") in driver.calls
+    assert ("send_keys", "password", "secret") in driver.calls
+    assert ("send_keys", "body", "hello") in driver.calls


### PR DESCRIPTION
## Summary
- implement a functional `MediumClient` plugin that uses the Selenium automation client
- add unit test covering posting via the Medium plugin
- update TODO

## Testing
- `pre-commit run --files src/auto/socials/medium_client.py tests/test_medium_social_plugin.py TODO.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bde4ffca8832ab2123064b4fdd0cd