### PR TITLE
Add dry-run option to create-preview

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -47,11 +47,12 @@ def generate_preview(c, post_id, network="mastodon"):
 
 
 @task
-def create_preview(c, post_id, network="mastodon", when=None):
+def create_preview(c, post_id, network="mastodon", when=None, dry_run=False):
     """Schedule preview generation."""
     when_flag = f"--when {when}" if when else ""
+    dry_flag = "--dry-run" if dry_run else ""
     c.run(
-        f"python -m auto.cli publish create-preview --post-id {post_id} --network {network} {when_flag}",
+        f"python -m auto.cli publish create-preview --post-id {post_id} --network {network} {when_flag} {dry_flag}",
         pty=True,
     )
 


### PR DESCRIPTION
## Summary
- add `dry_run` flag to `create_preview` command
- support dry-run in invoke `create_preview` task

## Testing
- `pre-commit run --files src/auto/cli/publish.py tasks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdeefc86c832a815ec4044318df09