### PR TITLE
Add list-schedule command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Substack content across multiple social sites with a single workflow.
 Posts are queued with the `python -m auto.cli publish schedule` command. The time argument accepts
 absolute ISO timestamps or relative values like `"+30m"`. Timestamps without a
 timezone are interpreted in UTC and stored as timezone-aware datetimes.
+Run `python -m auto.cli publish list-schedule` to see all upcoming posts and their networks.
 
 ## Managing previews
 

--- a/src/auto/cli/publish.py
+++ b/src/auto/cli/publish.py
@@ -98,6 +98,25 @@ def quick_post(network: str = "mastodon") -> None:
     schedule(post_id=post.id, time="in 1m", network=network)
 
 
+@app.command("list-schedule")
+def list_schedule() -> None:
+    """List scheduled posts with their network and timestamp."""
+
+    stmt = select(
+        PostStatus.post_id,
+        PostStatus.network,
+        PostStatus.scheduled_at,
+        PostStatus.status,
+    ).order_by(PostStatus.scheduled_at)
+
+    with SessionLocal() as session:
+        rows = session.execute(stmt).all()
+
+    for post_id, network, scheduled_at, status in rows:
+        when = scheduled_at.isoformat()
+        print(f"{post_id}\t{network}\t{when}\t{status}")
+
+
 @app.command()
 def trending_tags(
     limit: int = 10, instance: Optional[str] = None, token: Optional[str] = None
@@ -206,6 +225,7 @@ def edit_preview(post_id: str, network: str = "mastodon") -> None:
         session.commit()
     print("Preview updated")
 
+
 @app.command()
 def sync_mastodon_posts() -> None:
     """Mark posts as published if they already appear on Mastodon."""
@@ -217,4 +237,3 @@ def sync_mastodon_posts() -> None:
     with SessionLocal() as session:
         task = Task(type="sync_mastodon_posts")
         asyncio.run(handle_sync_mastodon_posts(task, session))
-

--- a/tasks.py
+++ b/tasks.py
@@ -38,6 +38,12 @@ def list_previews(c):
 
 
 @task
+def list_schedule(c):
+    """List scheduled posts across all networks."""
+    c.run("python -m auto.cli publish list-schedule", pty=True)
+
+
+@task
 def generate_preview(c, post_id, network="mastodon"):
     """Generate or update a preview for ``post_id``."""
     c.run(

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,4 +1,3 @@
-
 from auto.cli import publish as tasks
 from auto.cli.helpers import _parse_when  # noqa: E402
 from auto.db import SessionLocal  # noqa: E402
@@ -82,3 +81,32 @@ def test_parse_when_aware():
     result = _parse_when("2023-01-02T01:02:03+02:00")
     assert result == datetime(2023, 1, 1, 23, 2, 3, tzinfo=timezone.utc)
     assert result.tzinfo is timezone.utc
+
+
+def test_list_schedule_outputs(test_db_engine, capsys):
+    from datetime import datetime, timezone
+    from auto.models import Post
+
+    with SessionLocal() as session:
+        session.add(
+            Post(
+                id="1",
+                title="Title",
+                link="http://example",
+                summary="",
+                published="",
+            )
+        )
+        session.add(
+            PostStatus(
+                post_id="1",
+                network="mastodon",
+                scheduled_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        session.commit()
+
+    tasks.list_schedule()
+
+    captured = capsys.readouterr()
+    assert "1\tmastodon" in captured.out


### PR DESCRIPTION
## Summary
- show scheduled posts with `list-schedule` command
- expose list-schedule through invoke tasks
- document new command
- test CLI output

## Testing
- `pre-commit run --files src/auto/cli/publish.py tasks.py README.md tests/test_schedule.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdf78e028832a86de277bf71264d6