### PR TITLE
Add command collector to control_safari

### DIFF
--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -35,6 +35,7 @@ def _read_key() -> str:
         termios.tcsetattr(fd, termios.TCSADRAIN, old)
     return ch
 
+
 app = typer.Typer(help="Automation commands")
 
 
@@ -239,6 +240,7 @@ def test_task(codex_url: str = "https://chatgpt.com/codex") -> None:
 """
     controller.run_js(js)
 
+
 @app.command()
 def control_safari() -> None:
     """Interactively control Safari via a menu loop."""
@@ -252,6 +254,8 @@ def control_safari() -> None:
         ("close_tab", "Close the current tab"),
         ("quit", "Exit the menu"),
     ]
+
+    collected: list[tuple[str, ...]] = []
 
     while True:
         print("\nAvailable commands:")
@@ -269,27 +273,36 @@ def control_safari() -> None:
             break
         elif choice == "open":
             url = input("URL: ")
+            collected.append(("open", url))
             result = controller.open(url)
             if result:
                 print(result)
         elif choice == "click":
             selector = input("Selector: ")
+            collected.append(("click", selector))
             result = controller.click(selector)
             if result:
                 print(result)
         elif choice == "fill":
             selector = input("Selector: ")
             text = input("Text: ")
+            collected.append(("fill", selector, text))
             result = controller.fill(selector, text)
             if result:
                 print(result)
         elif choice == "run_js":
             code = input("JavaScript: ")
+            collected.append(("run_js", code))
             result = controller.run_js(code)
             if result:
                 print(result)
         elif choice == "close_tab":
+            collected.append(("close_tab",))
             result = controller.close_tab()
             if result:
                 print(result)
 
+    if collected:
+        print("\nCommand log:")
+        for entry in collected:
+            print(" ".join(entry))

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -1,5 +1,6 @@
 from auto.cli import automation as tasks
 
+
 class DummyController:
     def __init__(self):
         self.calls = []
@@ -25,18 +26,26 @@ class DummyController:
         return "OK"
 
 
-def test_control_safari(monkeypatch):
+def test_control_safari(monkeypatch, capsys):
     controller = DummyController()
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     key_inputs = iter(["1", "4", "6"])  # open, run_js, quit
-    text_inputs = iter([
-        "https://example.com",
-        "2+2",
-    ])
+    text_inputs = iter(
+        [
+            "https://example.com",
+            "2+2",
+        ]
+    )
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
 
     tasks.control_safari()
 
+    captured = capsys.readouterr()
+
     assert ("open", "https://example.com") in controller.calls
     assert ("run_js", "2+2") in controller.calls
+    out = captured.out
+    assert "Command log:" in out
+    assert "open https://example.com" in out
+    assert "run_js 2+2" in out


### PR DESCRIPTION
## Summary
- collect commands and arguments when running `control_safari`
- print the collected commands when quitting
- test new collector behaviour

## Testing
- `pre-commit run --files src/auto/cli/automation.py tests/test_control_safari.py`
- `pytest -q tests/test_control_safari.py`

------
https://chatgpt.com/codex/tasks/task_e_687be00fa740832aaff7fe1c651956d9