### PR TITLE
Move plugin registration and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Pass `--instance` and `--token` to override the defaults from the environment.
 
 ## Writing social network plugins
 
-Plugins implement the `SocialPlugin` protocol defined in `src/auto/socials/base.py`. Create a new module under `src/auto/socials/` with `post()` and `fetch_metrics()` methods and register an instance using `register_plugin()` from `src/auto/socials/registry.py`. The `network` attribute of the plugin is used to look it up when publishing. See `medium_client.py` for a minimal example.
+Plugins implement the `SocialPlugin` protocol defined in `src/auto/socials/base.py`. Create a module under `src/auto/socials/` and register an instance in `src/auto/socials/registry.py`. The plugin's `network` attribute is used to look it up when publishing. See [docs/plugins.md](docs/plugins.md) for a walkthrough and the `medium_client.py` example.
 
 
 ## Health checks

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## High Priority
 
 ## Medium Priority
-- Move plugin registration to `src/auto/socials/registry.py` and document how to write a plugin with an example `medium_client.py`.
 
 ## Low Priority
 - Expand social network support beyond Mastodon.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,9 +1,25 @@
-from __future__ import annotations
+# Writing Social Network Plugins
 
+Auto supports pluggable social network clients. Plugins implement the
+`SocialPlugin` protocol and register an instance in
+`src/auto/socials/registry.py`.
+
+## Creating a Plugin
+
+1. Add a module under `src/auto/socials/` that defines a class with
+   a ``network`` attribute and ``post()`` and ``fetch_metrics()`` methods.
+2. Import your class in `src/auto/socials/registry.py` and call
+   ``register_plugin(MyPlugin())``.
+
+The ``network`` string identifies the plugin when Auto publishes posts.
+
+## Example: MediumClient
+
+```python
+from __future__ import annotations
 import asyncio
 import logging
 from typing import Dict
-
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 
@@ -11,18 +27,13 @@ from .base import SocialPlugin
 
 logger = logging.getLogger(__name__)
 
-
 class MediumClient(SocialPlugin):
-    """SocialPlugin implementation using the Selenium automation client."""
-
     network = "medium"
 
     def __init__(self, driver: webdriver.Firefox | None = None) -> None:
         self.driver = driver
 
     async def post(self, text: str, visibility: str = "draft") -> None:
-        """Publish ``text`` as a new Medium draft."""
-
         await asyncio.to_thread(self._post_sync, text, visibility)
 
     def _post_sync(self, text: str, visibility: str) -> None:
@@ -42,3 +53,16 @@ class MediumClient(SocialPlugin):
     async def fetch_metrics(self, post_id: str) -> Dict[str, int]:
         logger.info("MediumClient.fetch_metrics called for %s", post_id)
         return {}
+```
+
+After defining the class, update `src/auto/socials/registry.py`:
+
+```python
+from .mastodon_client import MastodonClient
+from .medium_client import MediumClient
+
+register_plugin(MastodonClient())
+register_plugin(MediumClient())
+```
+
+Auto will then be able to publish posts to Medium using this plugin.

--- a/src/auto/socials/registry.py
+++ b/src/auto/socials/registry.py
@@ -17,5 +17,7 @@ def get_plugin(name: str) -> Optional[SocialPlugin]:
 
 # register built-in plugins
 from .mastodon_client import MastodonClient
+from .medium_client import MediumClient
 
 register_plugin(MastodonClient())
+register_plugin(MediumClient())


### PR DESCRIPTION
## Summary
- centralize plugin registration in registry
- remove self-registration from `medium_client`
- document plugin creation in new docs/plugins.md
- reference new plugin guide in README
- clean up TODO list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be08aacec832a9e9c894247c79127