### PR TITLE
Fix lint warnings

### DIFF
--- a/src/auto/automation/retro_planner.py
+++ b/src/auto/automation/retro_planner.py
@@ -39,7 +39,7 @@ class RetroPlanner:
             logger.warning("LLM replanning failed: %s", exc)
             return plan
 
-        lines = [l.strip() for l in response.splitlines() if l.strip()]
+        lines = [line.strip() for line in response.splitlines() if line.strip()]
         new_steps = [Step(id=i, description=line) for i, line in enumerate(lines, 1)]
         new_plan = Plan(objective=plan.objective, steps=new_steps)
         self.pm.save(new_plan)

--- a/src/auto/cli/helpers.py
+++ b/src/auto/cli/helpers.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from invoke import Exit
 import time
 
 from auto.automation.safari import SafariController

--- a/src/auto/git_utils.py
+++ b/src/auto/git_utils.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Git repository maintenance helpers."""
+
+from __future__ import annotations
 
 import subprocess
 from typing import List

--- a/src/auto/mastodon_sync.py
+++ b/src/auto/mastodon_sync.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 from sqlalchemy.orm import Session

--- a/src/auto/plan/logging.py
+++ b/src/auto/plan/logging.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
 from typing import Dict
 
 logger = logging.getLogger(__name__)

--- a/src/auto/plan/types.py
+++ b/src/auto/plan/types.py
@@ -9,7 +9,7 @@ import subprocess
 from dataclasses import dataclass, asdict, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional, Dict, Any
+from typing import List, Optional
 
 import logging
 

--- a/src/auto/socials/registry.py
+++ b/src/auto/socials/registry.py
@@ -1,6 +1,8 @@
 from typing import Dict, Optional
 
 from .base import SocialPlugin
+from .mastodon_client import MastodonClient
+from .medium_client import MediumClient
 
 _PLUGINS: Dict[str, SocialPlugin] = {}
 
@@ -16,8 +18,5 @@ def get_plugin(name: str) -> Optional[SocialPlugin]:
 
 
 # register built-in plugins
-from .mastodon_client import MastodonClient
-from .medium_client import MediumClient
-
 register_plugin(MastodonClient())
 register_plugin(MediumClient())

--- a/src/auto/spec_translator.py
+++ b/src/auto/spec_translator.py
@@ -65,7 +65,7 @@ def translate(spec_text: str) -> Dict[str, Any]:
             break
         if title:
             description_lines.append(line.strip())
-    description = " ".join(l for l in description_lines if l).strip()
+    description = " ".join(line_text for line_text in description_lines if line_text).strip()
 
     name = _sanitize_name(title or schema.get("title", "function"))
     if not description:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,8 @@ SRC = ROOT / "src"
 sys.path.insert(0, str(SRC))
 sys.path.insert(0, str(ROOT))
 
-from auto.feeds.ingestion import init_db
-from auto.db import SessionLocal
+from auto.feeds.ingestion import init_db  # noqa: E402
+from auto.db import SessionLocal  # noqa: E402
 
 
 def _check_dependencies() -> None:


### PR DESCRIPTION
## Summary
- fix ambiguous variable names and unused imports
- reorder imports and mark test fixtures with noqa
- ensure ruff passes

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be4963c90832a84a33d2c83466872