### PR TITLE
Align pre-commit linting with CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,15 @@ repos:
     hooks:
       - id: black
         language_version: python3
+        pass_filenames: false
+        args: [--check, .]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.3
     hooks:
       - id: ruff
-        args: [--fix]
+        pass_filenames: false
+        args: [.]
 
   - repo: local
     hooks:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Install the pre-commit hooks so formatting and linting run automatically:
 pre-commit install
 ```
 
+The hooks mirror the CI checks, running `ruff check .` and `black --check .` on
+every commit to ensure consistent formatting and linting.
+
 Use `python -m auto.cli maintenance update-deps` to upgrade outdated dependencies. Pass `--freeze` to
 rewrite `requirements.txt` after the upgrades.
 


### PR DESCRIPTION
## Summary
- ensure pre-commit mirrors CI black/ruff checks
- document the new behaviour in README

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be95df744832a994d161eefe96794