### PR TITLE
Refactor CLI async handling

### DIFF
--- a/src/auto/cli/__init__.py
+++ b/src/auto/cli/__init__.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import typer
+from .helpers import add_async_command
 
 from . import publish, automation, maintenance
 
 app = typer.Typer()
+add_async_command(app)
 app.add_typer(publish.app, name="publish")
 app.add_typer(automation.app, name="automation")
 app.add_typer(maintenance.app, name="maintenance")

--- a/src/auto/cli/publish.py
+++ b/src/auto/cli/publish.py
@@ -9,12 +9,13 @@ from datetime import datetime, timezone
 import typer
 from sqlalchemy import select, case
 
-from auto.cli.helpers import _parse_when
+from auto.cli.helpers import _parse_when, add_async_command
 from auto.db import SessionLocal
 from auto.models import Post, PostStatus, PostPreview, Task
 from auto.preview import create_preview as _create_preview
 
 app = typer.Typer(help="Publishing commands")
+add_async_command(app)
 
 
 @app.command()
@@ -239,14 +240,13 @@ def edit_preview(post_id: str, network: str = "mastodon") -> None:
     print("Preview updated")
 
 
-@app.command()
-def sync_mastodon_posts() -> None:
+@app.async_command()
+async def sync_mastodon_posts() -> None:
     """Mark posts as published if they already appear on Mastodon."""
-    import asyncio
     from auto.db import SessionLocal
     from auto.models import Task
     from auto.mastodon_sync import handle_sync_mastodon_posts
 
     with SessionLocal() as session:
         task = Task(type="sync_mastodon_posts")
-        asyncio.run(handle_sync_mastodon_posts(task, session))
+        await handle_sync_mastodon_posts(task, session)

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -1,5 +1,5 @@
-import asyncio
 import logging
+import anyio
 from typing import Optional
 
 import httpx
@@ -101,7 +101,7 @@ async def fetch_feed_async(feed_url: Optional[str] = None):
 
 def fetch_feed(feed_url: Optional[str] = None):
     """Synchronous wrapper around :func:`fetch_feed_async`."""
-    return asyncio.run(fetch_feed_async(feed_url))
+    return anyio.run(fetch_feed_async, feed_url)
 
 
 def _extract_text(item, name: str, default: str = ""):
@@ -190,12 +190,15 @@ async def run_ingest_async() -> None:
 
 def run_ingest() -> None:
     """Synchronous wrapper around :func:`run_ingest_async`."""
-    asyncio.run(run_ingest_async())
+    try:
+        anyio.from_thread.run(run_ingest_async)
+    except RuntimeError:
+        anyio.run(run_ingest_async)
 
 
 def main():
     init_db()
-    asyncio.run(run_ingest_async())
+    anyio.run(run_ingest_async)
 
 
 if __name__ == "__main__":

--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -1,7 +1,7 @@
 # main.py
 from fastapi import FastAPI, HTTPException
-import asyncio
 from contextlib import asynccontextmanager
+import asyncio
 from .feeds.ingestion import init_db, run_ingest
 from .scheduler import Scheduler
 from . import configure_logging

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import anyio
 import logging
 from datetime import datetime, timezone
 from typing import Optional, Callable, Awaitable, Dict
@@ -193,7 +194,7 @@ class Scheduler:
 
 
 def main():
-    asyncio.run(run_scheduler())
+    anyio.run(run_scheduler)
 
 
 if __name__ == "__main__":

--- a/src/auto/socials/mastodon_client.py
+++ b/src/auto/socials/mastodon_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import anyio
 import logging
 from typing import Dict
 import httpx
@@ -79,10 +80,10 @@ async def post_to_mastodon_async(status: str, visibility: str = "private") -> No
 
 def post_to_mastodon(status: str, visibility: str = "private") -> None:
     """Synchronous wrapper for :func:`post_to_mastodon_async`."""
-    asyncio.run(post_to_mastodon_async(status=status, visibility=visibility))
+    anyio.run(post_to_mastodon_async, status, visibility)
 
 
 if __name__ == "__main__":
-    asyncio.run(
-        post_to_mastodon_async("Hello world! My Substack → Socials bot is live 🚀")
+    anyio.run(
+        post_to_mastodon_async, "Hello world! My Substack → Socials bot is live 🚀"
     )


### PR DESCRIPTION
## Summary
- add `add_async_command` helper to register async Typer commands
- update publish CLI to use `@app.async_command`
- switch various modules from `asyncio.run` to `anyio.run`
- call `run_ingest` via `anyio.from_thread.run` when needed
- use `asyncio.to_thread(run_ingest)` in API endpoint

## Testing
- `pre-commit run --files src/auto/main.py src/auto/feeds/ingestion.py src/auto/cli/helpers.py src/auto/cli/__init__.py src/auto/cli/publish.py src/auto/scheduler.py src/auto/socials/mastodon_client.py`
- `pytest -q` *(fails: tests/test_api_ingest.py::test_ingest_endpoint - assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_687bf51b0b20832a94e76e27066f1144