### PR TITLE
Refactor social plugin registry

### DIFF
--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -7,6 +7,9 @@ from .scheduler import Scheduler
 from . import configure_logging
 from .metrics import router as metrics_router
 from .web_posts import router as posts_router
+from .socials import registry
+from .socials.mastodon_client import MastodonClient
+from .socials.medium_client import MediumClient
 import logging
 
 logger = logging.getLogger(__name__)
@@ -16,6 +19,9 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     configure_logging()
     init_db()
+    registry.plugins = registry.PluginRegistry()
+    registry.plugins.register(MastodonClient())
+    registry.plugins.register(MediumClient())
     sched = Scheduler()
     await sched.start()
     try:

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -12,7 +12,7 @@ from sqlalchemy import and_, or_
 from .models import PostStatus, Post, PostPreview, Task
 
 from .db import SessionLocal, get_engine
-from .socials.registry import get_plugin
+from .socials import registry
 
 # Temporary alias for tests using the old PLUGINS mapping
 from .metrics import POSTS_PUBLISHED, POSTS_FAILED
@@ -52,7 +52,9 @@ async def _publish(status: PostStatus, session: Session) -> None:
         session.commit()
         return
     try:
-        plugin = get_plugin(status.network)
+        if registry.plugins is None:
+            raise RuntimeError("Plugin registry not initialized")
+        plugin = registry.plugins.get(status.network)
         if plugin is None:
             raise ValueError(f"Unsupported network {status.network}")
         preview = session.get(

--- a/src/auto/socials/registry.py
+++ b/src/auto/socials/registry.py
@@ -1,22 +1,23 @@
 from typing import Dict, Optional
 
 from .base import SocialPlugin
-from .mastodon_client import MastodonClient
-from .medium_client import MediumClient
-
-_PLUGINS: Dict[str, SocialPlugin] = {}
 
 
-def register_plugin(plugin: SocialPlugin) -> None:
-    """Register a :class:`SocialPlugin` instance."""
-    _PLUGINS[plugin.network] = plugin
+class PluginRegistry:
+    """Container for :class:`SocialPlugin` instances."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, SocialPlugin] = {}
+
+    def register(self, plugin: SocialPlugin) -> None:
+        """Register ``plugin`` under its ``network`` name."""
+        self._plugins[plugin.network] = plugin
+
+    def get(self, name: str) -> Optional[SocialPlugin]:
+        """Return the plugin registered for ``name`` if any."""
+        return self._plugins.get(name)
 
 
-def get_plugin(name: str) -> Optional[SocialPlugin]:
-    """Return the plugin registered for ``name`` if any."""
-    return _PLUGINS.get(name)
-
-
-# register built-in plugins
-register_plugin(MastodonClient())
-register_plugin(MediumClient())
+# Global reference to the application's plugin registry. It is created during
+# application startup.
+plugins: PluginRegistry | None = None


### PR DESCRIPTION
## Summary
- encapsulate socials in a `PluginRegistry`
- create the registry during application startup
- access registered plugins through the instance in scheduler and tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf543e5b4832a8b8f69c5f30615ec