### PR TITLE
Fix logging configuration re-entry

### DIFF
--- a/src/auto/__init__.py
+++ b/src/auto/__init__.py
@@ -12,7 +12,14 @@ def configure_logging() -> None:
     """
 
     load_env()
-    logging.basicConfig(
-        level=os.getenv("LOG_LEVEL", "INFO"),
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    )
+    level = os.getenv("LOG_LEVEL", "INFO")
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        root_logger.setLevel(level)
+        for handler in root_logger.handlers:
+            handler.setLevel(level)
+    else:
+        logging.basicConfig(
+            level=level,
+            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        )

--- a/src/auto/plan/logging.py
+++ b/src/auto/plan/logging.py
@@ -11,12 +11,14 @@ logger = logging.getLogger(__name__)
 
 def configure_logging() -> None:
     """Initialize logging when the plan executor starts."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s [%(levelname)s] %(message)s",
-        filename="agent.log",
-        filemode="a",
-    )
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s [%(levelname)s] %(message)s",
+            filename="agent.log",
+            filemode="a",
+        )
 
 
 class ExecutionLogger:


### PR DESCRIPTION
## Summary
- prevent duplicate handlers in `configure_logging`
- guard plan logging against multiple initializations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bf4ffff58832a9241758efe4cbd62