### PR TITLE
Refactor scheduler task registration

### DIFF
--- a/src/auto/ingest_scheduler.py
+++ b/src/auto/ingest_scheduler.py
@@ -6,12 +6,12 @@ from datetime import datetime, timezone, timedelta
 from .feeds.ingestion import run_ingest_async
 from .config import get_ingest_interval
 from .models import Task
-from .scheduler import register_task_handler
+from .scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
 
 
-@register_task_handler("ingest_feed")
+@Scheduler.register_task_handler("ingest_feed")
 async def handle_ingest_feed(task: Task, session) -> None:
     """Run feed ingestion and schedule the next run."""
     try:

--- a/src/auto/mastodon_sync.py
+++ b/src/auto/mastodon_sync.py
@@ -3,7 +3,7 @@ import logging
 from sqlalchemy.orm import Session
 
 from .socials.mastodon_client import MastodonClient
-from .scheduler import register_task_handler
+from .scheduler import Scheduler
 from .models import Post, PostStatus, Task
 from .config import get_mastodon_sync_debug
 
@@ -15,7 +15,7 @@ async def _fetch_status_texts(client: MastodonClient) -> list[str]:
     return [s.get("content", "") for s in statuses]
 
 
-@register_task_handler("sync_mastodon_posts")
+@Scheduler.register_task_handler("sync_mastodon_posts")
 async def handle_sync_mastodon_posts(task: Task, session: Session) -> None:
     """Mark posts as published if they already appear on Mastodon."""
     client = MastodonClient()

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -26,20 +26,89 @@ from .preview import create_preview as _create_preview
 
 logger = logging.getLogger(__name__)
 
-TASK_HANDLERS: Dict[str, Callable[[Task, Session], Awaitable[None]]] = {}
 
+class Scheduler:
+    """Manage scheduled task execution."""
 
-def register_task_handler(
-    name: str,
-) -> Callable[
-    [Callable[[Task, Session], Awaitable[None]]],
-    Callable[[Task, Session], Awaitable[None]],
-]:
-    def decorator(func: Callable[[Task, Session], Awaitable[None]]):
-        TASK_HANDLERS[name] = func
-        return func
+    task_handlers: Dict[str, Callable[[Task, Session], Awaitable[None]]] = {}
 
-    return decorator
+    def __init__(self) -> None:
+        self._worker = PeriodicWorker(self.process_pending, get_poll_interval)
+
+    @classmethod
+    def register_task_handler(
+        cls, name: str
+    ) -> Callable[[Callable[[Task, Session], Awaitable[None]]], Callable[[Task, Session], Awaitable[None]]]:
+        def decorator(func: Callable[[Task, Session], Awaitable[None]]):
+            cls.task_handlers[name] = func
+            return func
+
+        return decorator
+
+    async def start(self) -> Optional[asyncio.Task]:
+        """Start the background scheduler loop."""
+        if self._worker.task is None or self._worker.task.done():
+            from sqlalchemy import inspect
+
+            inspector = inspect(get_engine())
+            if not inspector.has_table("tasks"):
+                logger.warning("tasks table missing; scheduler not started")
+                return None
+
+            # ensure ingest handler and other task handlers are registered
+            from . import ingest_scheduler
+
+            with SessionLocal() as session:
+                ingest_scheduler.ensure_initial_task(session)
+                session.commit()
+
+            await self._worker.start()
+        return self._worker.task
+
+    async def stop(self) -> None:
+        """Stop the background scheduler loop."""
+        await self._worker.stop()
+
+    async def process_pending(self, max_attempts: Optional[int] = None) -> None:
+        """Fetch due tasks and dispatch them to registered handlers."""
+        now = datetime.now(timezone.utc)
+        if max_attempts is None:
+            max_attempts = get_max_attempts()
+        with SessionLocal() as session:
+            tasks = (
+                session.query(Task)
+                .filter(
+                    Task.scheduled_at <= now,
+                    or_(
+                        Task.status == "pending",
+                        and_(Task.status == "error", Task.attempts < max_attempts),
+                    ),
+                )
+                .order_by(Task.scheduled_at)
+                .all()
+            )
+
+            for task in tasks:
+                handler = self.task_handlers.get(task.type)
+                if handler is None:
+                    task.status = "error"
+                    task.last_error = f"no handler for {task.type}"
+                    task.attempts += 1
+                    session.commit()
+                    continue
+                task.status = "running"
+                session.commit()
+                try:
+                    await handler(task, session)
+                    task.status = "completed"
+                    task.last_error = None
+                except Exception as exc:
+                    task.status = "error"
+                    task.last_error = str(exc)
+                    logger.error("Task %s failed: %s", task.type, exc)
+                finally:
+                    task.attempts += 1
+                    session.commit()
 
 
 async def _publish(status: PostStatus, session: Session) -> None:
@@ -80,7 +149,9 @@ async def _publish(status: PostStatus, session: Session) -> None:
         await asyncio.sleep(get_post_delay())
 
 
-@register_task_handler("publish_post")
+
+
+@Scheduler.register_task_handler("publish_post")
 async def handle_publish_post(task: Task, session: Session) -> None:
     data = json.loads(task.payload or "{}")
     post_id = data.get("post_id")
@@ -91,58 +162,12 @@ async def handle_publish_post(task: Task, session: Session) -> None:
     await _publish(status, session)
 
 
-@register_task_handler("create_preview")
+@Scheduler.register_task_handler("create_preview")
 async def handle_create_preview(task: Task, session: Session) -> None:
     data = json.loads(task.payload or "{}")
     post_id = data.get("post_id")
     network = data.get("network", "mastodon")
     _create_preview(session, post_id, network)
-
-
-async def process_pending(max_attempts: Optional[int] = None) -> None:
-    """Fetch due tasks and dispatch them to registered handlers."""
-    now = datetime.now(timezone.utc)
-    if max_attempts is None:
-        max_attempts = get_max_attempts()
-    with SessionLocal() as session:
-        tasks = (
-            session.query(Task)
-            .filter(
-                Task.scheduled_at <= now,
-                or_(
-                    Task.status == "pending",
-                    and_(Task.status == "error", Task.attempts < max_attempts),
-                ),
-            )
-            .order_by(Task.scheduled_at)
-            .all()
-        )
-
-        for task in tasks:
-            handler = TASK_HANDLERS.get(task.type)
-            if handler is None:
-                task.status = "error"
-                task.last_error = f"no handler for {task.type}"
-                task.attempts += 1
-                session.commit()
-                continue
-            task.status = "running"
-            session.commit()
-            try:
-                await handler(task, session)
-                task.status = "completed"
-                task.last_error = None
-            except Exception as exc:
-                task.status = "error"
-                task.last_error = str(exc)
-                logger.error("Task %s failed: %s", task.type, exc)
-            finally:
-                task.attempts += 1
-                session.commit()
-
-
-async def _scheduler_iteration() -> None:
-    await process_pending()
 
 
 async def run_scheduler() -> None:
@@ -163,35 +188,6 @@ async def run_scheduler() -> None:
         logger.info("Scheduler stopped")
 
 
-class Scheduler:
-    """Manage the background scheduler task without relying on globals."""
-
-    def __init__(self) -> None:
-        self._worker = PeriodicWorker(_scheduler_iteration, get_poll_interval)
-
-    async def start(self) -> Optional[asyncio.Task]:
-        """Start the background scheduler loop."""
-        if self._worker.task is None or self._worker.task.done():
-            from sqlalchemy import inspect
-
-            inspector = inspect(get_engine())
-            if not inspector.has_table("tasks"):
-                logger.warning("tasks table missing; scheduler not started")
-                return None
-
-            # ensure ingest handler and other task handlers are registered
-            from . import ingest_scheduler
-
-            with SessionLocal() as session:
-                ingest_scheduler.ensure_initial_task(session)
-                session.commit()
-
-            await self._worker.start()
-        return self._worker.task
-
-    async def stop(self) -> None:
-        """Stop the background scheduler loop."""
-        await self._worker.stop()
 
 
 def main():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,7 +8,7 @@ from auto.socials import registry
 from auto.socials.registry import PluginRegistry
 from auto.socials.mastodon_client import MastodonClient
 import pytest
-from auto.scheduler import process_pending, Scheduler
+from auto.scheduler import Scheduler
 from auto.metrics import POSTS_PUBLISHED, POSTS_FAILED
 
 
@@ -29,7 +29,8 @@ def setup_plugins():
 
 
 async def run_process():
-    await process_pending()
+    sched = Scheduler()
+    await sched.process_pending()
 
 
 def test_publish_post_task(test_db_engine, monkeypatch):


### PR DESCRIPTION
## Summary
- add a `task_handlers` mapping to `Scheduler`
- turn `register_task_handler` into a class method
- use `Scheduler.register_task_handler` in ingest and sync handlers
- make `process_pending` an instance method
- update scheduler tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0dda9030832aadbe0ffa7c06c710