### PR TITLE
Add list-substacks CLI and task

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ absolute ISO timestamps or relative values like `"+30m"`. Timestamps without a
 timezone are interpreted in UTC and stored as timezone-aware datetimes.
 Run `python -m auto.cli publish list-schedule` to see all upcoming posts and their networks.
 
+### Listing Substack posts
+
+View stored posts from the RSS feed with:
+
+```bash
+python -m auto.cli publish list-substacks
+```
+
+Use `-p` for only shared posts or `-u` for those not yet shared.
+
 ## Managing previews
 
 Previews are small templates used when posting to other networks. They can be listed, generated or edited with CLI commands:

--- a/tasks.py
+++ b/tasks.py
@@ -43,6 +43,22 @@ def list_previews(c):
     c.run("python -m auto.cli publish list-previews", pty=True)
 
 
+@task(
+    help={
+        "published": "Only show posts that have been shared",
+        "unpublished": "Only show posts not yet shared",
+    }
+)
+def list_substacks(c, published=False, unpublished=False):
+    """List posts from the database."""
+    pub_flag = "-p" if published else ""
+    unpub_flag = "-u" if unpublished else ""
+    c.run(
+        f"python -m auto.cli publish list-substacks {pub_flag} {unpub_flag}",
+        pty=True,
+    )
+
+
 @task
 def list_schedule(c):
     """List scheduled posts across all networks."""

--- a/tests/test_list_substacks.py
+++ b/tests/test_list_substacks.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone
+
+from auto.cli import publish as tasks
+from auto.db import SessionLocal
+from auto.models import Post, PostStatus
+
+
+def _setup_posts() -> None:
+    with SessionLocal() as session:
+        session.add(
+            Post(
+                id="1",
+                title="One",
+                link="http://1",
+                summary="",
+                published="2020",
+                created_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        session.add(
+            Post(
+                id="2",
+                title="Two",
+                link="http://2",
+                summary="",
+                published="2019",
+                created_at=datetime(2019, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        session.add(PostStatus(post_id="1", network="mastodon", status="published"))
+        session.commit()
+
+
+def test_list_substacks_outputs(test_db_engine, capsys):
+    _setup_posts()
+
+    tasks.list_substacks()
+
+    out = capsys.readouterr().out
+    assert "1\tOne\tpublished" in out
+    assert "2\tTwo\tpending" in out
+
+
+def test_list_substacks_filters(test_db_engine, capsys):
+    _setup_posts()
+
+    tasks.list_substacks(published=True, unpublished=False)
+    out = capsys.readouterr().out
+    assert "One" in out
+    assert "Two" not in out
+
+    tasks.list_substacks(published=False, unpublished=True)
+    out = capsys.readouterr().out
+    assert "One" not in out
+    assert "Two" in out


### PR DESCRIPTION
## Summary
- add `list-substacks` CLI to show posts with filtering
- expose new command via invoke `list_substacks` task
- document how to list Substack posts
- test new command

## Testing
- `pre-commit run --files README.md src/auto/cli/publish.py tasks.py tests/test_list_substacks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d029798b8832a99d1cd1866f07815