### PR TITLE
Improve fetch_dom logging

### DIFF
--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -308,10 +308,10 @@ def control_safari() -> None:
             if result:
                 print(result)
         elif choice == "fetch_dom":
-            collected.append(("fetch_dom",))
             dom = fetch_dom_html()
             dest = test_dir / f"{step}.html"
             dest.write_text(dom)
+            collected.append(("fetch_dom", str(dest)))
             step += 1
             print(f"Saved DOM to {dest}")
         elif choice == "close_tab":

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -54,7 +54,7 @@ def test_control_safari(monkeypatch, capsys):
     assert (test_dir / "1.html").exists()
     log = json.loads((test_dir / "commands.json").read_text())
     assert log[0] == ["open", "https://example.com"]
-    assert log[1] == ["fetch_dom"]
+    assert log[1] == ["fetch_dom", str(test_dir / "1.html")]
 
     out = captured.out
     assert "Command log:" in out


### PR DESCRIPTION
## Summary
- link DOM capture filenames to the corresponding `fetch_dom` command
- update control_safari unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d056ba5e0832a840e35a7279ef041