### PR TITLE
Update fetch_dom to use current Safari tab

### DIFF
--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -124,10 +124,10 @@ def codex_todo() -> None:
 
 
 @app.command()
-def fetch_dom() -> None:
-    """Open the Codex page and print the full DOM tree."""
+def fetch_dom(url: str | None = None) -> None:
+    """Print the DOM for the current tab or ``url``."""
 
-    dom = fetch_dom_html()
+    dom = fetch_dom_html(url)
     if dom:
         print(dom)
         dest = Path("tests/fixtures/dom.html")
@@ -139,7 +139,7 @@ def fetch_dom() -> None:
 def count_links(url: str = "https://chatgpt.com/codex") -> None:
     """Download ``url`` and report merged vs active link counts."""
 
-    dom = fetch_dom_html()
+    dom = fetch_dom_html(url)
     merged, active = count_link_states(dom)
     print(f"Merged links: {merged}")
     print(f"Active tasks: {active}")

--- a/src/auto/html_helpers.py
+++ b/src/auto/html_helpers.py
@@ -6,10 +6,12 @@ from .automation.safari import SafariController
 from .html_utils import extract_links_with_green_span
 
 
-def fetch_dom(url: str = "https://chatgpt.com/codex") -> str:
-    """Return the full DOM tree for ``url`` using Safari."""
+def fetch_dom(url: str | None = None) -> str:
+    """Return the DOM tree for ``url`` or the active tab via Safari."""
+
     controller = SafariController()
-    controller.open(url)
+    if url:
+        controller.open(url)
     return controller.run_js("document.documentElement.outerHTML")
 
 

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -32,7 +32,7 @@ class DummyController:
 def test_control_safari(monkeypatch, capsys):
     controller = DummyController()
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
-    monkeypatch.setattr(tasks, "fetch_dom_html", lambda: "<html></html>")
+    monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
 
     key_inputs = iter(["1", "5", "7"])  # open, fetch_dom, quit
     text_inputs = iter(


### PR DESCRIPTION
## Summary
- allow `fetch_dom` to capture DOM from the active Safari tab
- pass optional URL through CLI commands
- adjust interactive control test for new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0ec5c7bc832a912f8db7031c976c