### PR TITLE
Fix Typer union type incompatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,5 @@ These principles emphasize explicit initialization, safe resource handling, and 
 - When parsing feed entries, rely on the `_extract_text` helper in `feeds/ingestion.py` rather than branching on entry types.
 - Avoid using Selenium for browser automation. Use the `SafariController`
   AppleScript from `automation/safari.py` instead.
+- Typer doesn't support the ``str | None`` syntax. Use ``Optional[str]`` for
+  command parameters.

--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -134,7 +134,7 @@ def codex_todo() -> None:
 
 
 @app.command()
-def fetch_dom(url: str | None = None) -> None:
+def fetch_dom(url: Optional[str] = None) -> None:
     """Print the DOM for the current tab or ``url``."""
 
     dom = fetch_dom_html(url)

--- a/src/auto/cli/helpers.py
+++ b/src/auto/cli/helpers.py
@@ -12,7 +12,7 @@ from auto.automation.safari import SafariController
 from dateutil import parser
 import anyio
 import typer
-from typing import Callable, Any
+from typing import Callable, Any, Optional
 from functools import wraps
 
 
@@ -68,7 +68,7 @@ def _parse_when(value: str) -> datetime:
     return dt
 
 
-def _get_medium_magic_link() -> str | None:
+def _get_medium_magic_link() -> Optional[str]:
     """Return the latest Medium magic link via Apple Mail if present."""
     script = Path(__file__).resolve().parents[1] / "scripts" / "fetch_medium_link.scpt"
     result = subprocess.run(["osascript", str(script)], capture_output=True, text=True)

--- a/src/auto/config.py
+++ b/src/auto/config.py
@@ -1,5 +1,6 @@
 import os
 from dotenv import load_dotenv, find_dotenv
+from typing import Optional
 
 DEFAULT_FEED_URL = "https://geoffreyducharme.substack.com/feed"
 
@@ -33,7 +34,7 @@ def get_mastodon_instance() -> str:
     return os.getenv("MASTODON_INSTANCE", "https://mastodon.social")
 
 
-def get_mastodon_token() -> str | None:
+def get_mastodon_token() -> Optional[str]:
     load_env()
     return os.getenv("MASTODON_TOKEN")
 
@@ -59,12 +60,12 @@ def get_max_attempts() -> int:
     return int(os.getenv("MAX_ATTEMPTS", "3"))
 
 
-def get_medium_email() -> str | None:
+def get_medium_email() -> Optional[str]:
     load_env()
     return os.getenv("MEDIUM_EMAIL")
 
 
-def get_medium_password() -> str | None:
+def get_medium_password() -> Optional[str]:
     load_env()
     return os.getenv("MEDIUM_PASSWORD")
 

--- a/src/auto/html_helpers.py
+++ b/src/auto/html_helpers.py
@@ -4,9 +4,10 @@ from bs4 import BeautifulSoup
 
 from .automation.safari import SafariController
 from .html_utils import extract_links_with_green_span
+from typing import Optional
 
 
-def fetch_dom(url: str | None = None) -> str:
+def fetch_dom(url: Optional[str] = None) -> str:
     """Return the DOM tree for ``url`` or the active tab via Safari."""
 
     controller = SafariController()


### PR DESCRIPTION
## Summary
- use Optional[str] instead of `str | None` for CLI parameters
- update AGENTS guidelines about the Typer union limitation

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_687d23c5bea0832a95ac2326d1ef6bfc