### PR TITLE
Add invoke task for replay feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ DOM snapshots and backups are written alongside the plan so failures can be
 inspected or rolled back. Use the `--reset` flag to delete the working plan and
 all generated artifacts.
 
+Recorded browser sessions can be replayed with:
+
+```bash
+python -m auto.cli automation replay facebook
+```
+
 ## Running tests
 
 Before running tests, install the project dependencies. The

--- a/tasks.py
+++ b/tasks.py
@@ -175,6 +175,12 @@ def safari_control(c):
     c.run("python -m auto.cli automation control-safari", pty=True)
 
 
+@task(help={"name": "Fixture name under tests/fixtures"})
+def replay(c, name="facebook"):
+    """Replay recorded Safari commands."""
+    c.run(f"python -m auto.cli automation replay {name}", pty=True)
+
+
 @task
 def parse_plan(c):
     """Parse PLAN.md into task files."""

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -14,29 +14,92 @@ class DummyContext(Context):
     def run(self, cmd, *_, pty=False, **__):  # type: ignore[override]
         self.commands.append((cmd, pty))
 
+
 TEST_CASES = [
     (inv.install_deps, [], {}, "pip install -r requirements.txt"),
-    (inv.uv, [], {}, "python -m auto.cli maintenance uv --host 127.0.0.1 --port 8000 --reload"),
+    (
+        inv.uv,
+        [],
+        {},
+        "python -m auto.cli maintenance uv --host 127.0.0.1 --port 8000 --reload",
+    ),
     (inv.scheduler, [], {}, "python -m auto.scheduler"),
     (inv.ingest, [], {}, "python -m auto.cli maintenance ingest"),
     (inv.list_previews, [], {}, "python -m auto.cli publish list-previews"),
-    (inv.list_substacks, [], {"published": True, "unpublished": True}, "python -m auto.cli publish list-substacks -p -u"),
+    (
+        inv.list_substacks,
+        [],
+        {"published": True, "unpublished": True},
+        "python -m auto.cli publish list-substacks -p -u",
+    ),
     (inv.list_schedule, [], {}, "python -m auto.cli publish list-schedule"),
-    (inv.generate_preview, [123], {}, "python -m auto.cli publish generate-preview --post-id 123 --network mastodon"),
-    (inv.create_preview, [123], {"when": "now", "dry_run": True}, "python -m auto.cli publish create-preview --post-id 123 --network mastodon --when now --dry-run"),
-    (inv.edit_preview, [123], {"network": "twitter"}, "python -m auto.cli publish edit-preview --post-id 123 --network twitter"),
-    (inv.trending_tags, [], {"limit": 3, "instance": "mastodon.social", "token": "tok"}, "python -m auto.cli publish trending-tags --limit 3 --instance mastodon.social --token tok"),
+    (
+        inv.generate_preview,
+        [123],
+        {},
+        "python -m auto.cli publish generate-preview --post-id 123 --network mastodon",
+    ),
+    (
+        inv.create_preview,
+        [123],
+        {"when": "now", "dry_run": True},
+        "python -m auto.cli publish create-preview --post-id 123 --network mastodon --when now --dry-run",
+    ),
+    (
+        inv.edit_preview,
+        [123],
+        {"network": "twitter"},
+        "python -m auto.cli publish edit-preview --post-id 123 --network twitter",
+    ),
+    (
+        inv.trending_tags,
+        [],
+        {"limit": 3, "instance": "mastodon.social", "token": "tok"},
+        "python -m auto.cli publish trending-tags --limit 3 --instance mastodon.social --token tok",
+    ),
     (inv.sync_mastodon_posts, [], {}, "python -m auto.cli publish sync-mastodon-posts"),
-    (inv.update_deps, [], {"freeze": True}, "python -m auto.cli maintenance update-deps --freeze"),
-    (inv.cleanup_branches, [], {"remote": "up", "main": "dev"}, "python -m auto.cli maintenance cleanup-branches --remote up --main dev"),
-    (inv.metrics, [], {"host": "0.0.0.0", "port": 9000}, "python -m auto.cli maintenance metrics --host 0.0.0.0 --port 9000"),
+    (
+        inv.update_deps,
+        [],
+        {"freeze": True},
+        "python -m auto.cli maintenance update-deps --freeze",
+    ),
+    (
+        inv.cleanup_branches,
+        [],
+        {"remote": "up", "main": "dev"},
+        "python -m auto.cli maintenance cleanup-branches --remote up --main dev",
+    ),
+    (
+        inv.metrics,
+        [],
+        {"host": "0.0.0.0", "port": 9000},
+        "python -m auto.cli maintenance metrics --host 0.0.0.0 --port 9000",
+    ),
     (inv.safari_control, [], {}, "python -m auto.cli automation control-safari"),
-    (inv.parse_plan, [], {}, "python -c 'from auto.plan.parser import parse_plan; parse_plan(\"PLAN.md\")'"),
-    (inv.execute_plan, [], {"plan": "plan.json"}, "python -m auto.automation.plan_executor plan.json"),
+    (
+        inv.replay,
+        [],
+        {"name": "facebook"},
+        "python -m auto.cli automation replay facebook",
+    ),
+    (
+        inv.parse_plan,
+        [],
+        {},
+        "python -c 'from auto.plan.parser import parse_plan; parse_plan(\"PLAN.md\")'",
+    ),
+    (
+        inv.execute_plan,
+        [],
+        {"plan": "plan.json"},
+        "python -m auto.automation.plan_executor plan.json",
+    ),
     (inv.install_hooks, [], {}, "pre-commit install"),
     (inv.tests, [], {"marker": "unit"}, "pytest -m unit"),
     (inv.help, [], {}, "invoke --list"),
 ]
+
 
 @pytest.mark.parametrize("func,args,kwargs,expected", TEST_CASES)
 def test_invoke_tasks(func, args, kwargs, expected):


### PR DESCRIPTION
## Summary
- expose browser command replay as an Invoke task
- test new replay task invocation
- document how to replay recorded browser sessions

## Testing
- `pre-commit run --files tasks.py tests/test_invoke_tasks.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2cb3d28c832a81a43c3dde6a16e9