### PR TITLE
Fix invoke replay param forwarding

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -178,7 +178,10 @@ def safari_control(c):
 @task(help={"name": "Fixture name under tests/fixtures"})
 def replay(c, name="facebook"):
     """Replay recorded Safari commands."""
-    c.run(f"python -m auto.cli automation replay {name}", pty=True)
+    cmd = "python -m auto.cli automation replay"
+    if name != "facebook":
+        cmd += f" --name {name}"
+    c.run(cmd, pty=True)
 
 
 @task

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -81,7 +81,13 @@ TEST_CASES = [
         inv.replay,
         [],
         {"name": "facebook"},
-        "python -m auto.cli automation replay facebook",
+        "python -m auto.cli automation replay",
+    ),
+    (
+        inv.replay,
+        [],
+        {"name": "twitter"},
+        "python -m auto.cli automation replay --name twitter",
     ),
     (
         inv.parse_plan,


### PR DESCRIPTION
## Summary
- fix `invoke replay` to pass --name correctly
- update corresponding tests

## Testing
- `pytest -k invoke_tasks -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5a121368832aab2cd66c37128124