### PR TITLE
Allow recording additional Safari steps after replay

### DIFF
--- a/tests/test_replay_continue.py
+++ b/tests/test_replay_continue.py
@@ -1,0 +1,53 @@
+import json
+import shutil
+from pathlib import Path
+
+from auto.cli import automation as tasks
+
+
+class DummyController:
+    def __init__(self):
+        self.calls = []
+
+    def open(self, url):
+        self.calls.append(("open", url))
+        return "OK"
+
+    def click(self, selector):
+        self.calls.append(("click", selector))
+        return "OK"
+
+    def fill(self, selector, text):
+        self.calls.append(("fill", selector, text))
+        return "OK"
+
+    def run_js(self, code):
+        self.calls.append(("run_js", code))
+        return "OK"
+
+    def close_tab(self):
+        self.calls.append(("close_tab",))
+        return "OK"
+
+
+def test_replay_continue(monkeypatch, tmp_path):
+    src = Path("tests/fixtures/facebook")
+    dst = tmp_path / "tests" / "fixtures" / "facebook"
+    shutil.copytree(src, dst)
+    monkeypatch.chdir(tmp_path)
+
+    controller = DummyController()
+    monkeypatch.setattr(tasks, "SafariController", lambda: controller)
+    monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
+
+    key_inputs = iter(["5", "7"])  # fetch_dom then quit
+    monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
+    inputs = iter(["y"])  # continue recording
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    tasks.replay("facebook")
+
+    commands = json.loads((dst / "commands.json").read_text())
+    assert (dst / "3.html").exists()
+    assert len(commands) == 5
+    assert commands[-1] == ["fetch_dom", "tests/fixtures/facebook/3.html"]


### PR DESCRIPTION
## Summary
- factor Safari control menu into `_interactive_menu`
- add `_next_step` helper for DOM snapshot numbering
- enable prompting to continue recording after replay completes
- test that continuing a replay records a new step

## Testing
- `pre-commit run --files src/auto/cli/automation.py tests/test_replay_continue.py`
- `pytest -q tests/test_replay_continue.py`


------
https://chatgpt.com/codex/tasks/task_e_687d67a649f0832aa232b5e269fc44ec