### PR TITLE
Add SKIP_SLOW_PRINT env toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following variables are used:
   default `600`.
 - `POST_DELAY` – pause after each publish attempt, default `1` second.
 - `MASTODON_SYNC_DEBUG` – set to `1` to print Mastodon statuses during sync.
+- `SKIP_SLOW_PRINT` – set to `1` to disable delays in CLI output.
 - `LOG_LEVEL` – log verbosity used by `configure_logging()`, default `INFO`.
 
 Log output is sent to stdout when `configure_logging()` is called at

--- a/src/auto/cli/helpers.py
+++ b/src/auto/cli/helpers.py
@@ -27,9 +27,15 @@ def _delay(seconds: float) -> None:
 
 
 def _slow_print(message: str) -> None:
-    """Print ``message`` then pause for a short delay."""
+    """Print ``message`` then pause for a short delay.
+
+    Set ``SKIP_SLOW_PRINT=1`` to disable the wait. ``TASKS_DELAY`` is still
+    respected when this variable is unset.
+    """
     print(message)
-    _delay(5)
+    skip = os.getenv("SKIP_SLOW_PRINT", "0").lower()
+    if skip not in {"1", "true", "yes"}:
+        _delay(5)
 
 
 def freeze_requirements() -> None:

--- a/tests/test_replay_continue.py
+++ b/tests/test_replay_continue.py
@@ -39,6 +39,7 @@ def test_replay_continue(monkeypatch, tmp_path):
     controller = DummyController()
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
+    monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
 
     key_inputs = iter(["5", "7"])  # fetch_dom then quit
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))


### PR DESCRIPTION
## Summary
- add SKIP_SLOW_PRINT env var to `_slow_print`
- skip slow printing in replay test
- document the new variable in README

## Testing
- `pre-commit run --files src/auto/cli/helpers.py tests/test_replay_continue.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6db708a0832aa5391e10cb2a55f8