### PR TITLE
Enhance Safari automation JS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,16 @@ Recorded browser sessions can be replayed with:
 python -m auto.cli automation replay facebook
 ```
 
+For ad-hoc experimentation you can launch an interactive Safari control menu:
+
+```bash
+python -m auto.cli automation control-safari
+```
+
+Alongside opening pages and clicking selectors, the menu now includes a
+"run_js_file" option to execute JavaScript from a file. This makes it easy to
+inject helper functions and call them later.
+
 ## Running tests
 
 Before running tests, install the project dependencies. The

--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -278,6 +278,7 @@ def _interactive_menu(
         ("click", "Click an element by CSS selector"),
         ("fill", "Fill a selector with text"),
         ("run_js", "Run arbitrary JavaScript"),
+        ("run_js_file", "Run JavaScript from a file"),
         ("fetch_dom", "Save page DOM to fixture"),
         ("close_tab", "Close the current tab"),
         ("quit", "Exit the menu"),
@@ -319,6 +320,14 @@ def _interactive_menu(
         elif choice == "run_js":
             code = input("JavaScript: ")
             collected.append(["run_js", code])
+            result = controller.run_js(code)
+            if result:
+                print(result)
+        elif choice == "run_js_file":
+            path_str = input("JS file path: ")
+            path = Path(path_str)
+            code = path.read_text()
+            collected.append(["run_js_file", path_str])
             result = controller.run_js(code)
             if result:
                 print(result)
@@ -392,6 +401,13 @@ def replay(name: str = "facebook") -> None:
         elif cmd == "run_js" and args:
             _slow_print("Running JavaScript")
             controller.run_js(args[0])
+        elif cmd == "run_js_file" and args:
+            path = Path(args[0])
+            if path.exists():
+                _slow_print(f"Running JavaScript from {path}")
+                controller.run_js(path.read_text())
+            else:
+                typer.echo(f"JS file not found: {path}")
         elif cmd == "close_tab":
             _slow_print("Closing tab")
             controller.close_tab()

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -34,7 +34,7 @@ def test_control_safari(monkeypatch, capsys):
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
 
-    key_inputs = iter(["1", "5", "7"])  # open, fetch_dom, quit
+    key_inputs = iter(["1", "6", "8"])  # open, fetch_dom, quit
     text_inputs = iter(
         [
             "demo_test",
@@ -60,3 +60,24 @@ def test_control_safari(monkeypatch, capsys):
     assert "Command log:" in out
 
     shutil.rmtree(test_dir)
+
+
+def test_control_safari_run_js_file(monkeypatch, tmp_path):
+    controller = DummyController()
+    monkeypatch.setattr(tasks, "SafariController", lambda: controller)
+    js_path = tmp_path / "helper.js"
+    js_code = "console.log('hello');"
+    js_path.write_text(js_code)
+
+    key_inputs = iter(["5", "8"])  # run_js_file, quit
+    text_inputs = iter([
+        "demo_js",
+        str(js_path),
+    ])
+    monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
+    monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
+
+    tasks.control_safari()
+
+    assert ("run_js", js_code) in controller.calls
+    shutil.rmtree(Path("tests/fixtures/demo_js"))

--- a/tests/test_replay_continue.py
+++ b/tests/test_replay_continue.py
@@ -41,7 +41,7 @@ def test_replay_continue(monkeypatch, tmp_path):
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
     monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
 
-    key_inputs = iter(["5", "7"])  # fetch_dom then quit
+    key_inputs = iter(["6", "8"])  # fetch_dom then quit
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     inputs = iter(["y"])  # continue recording
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))


### PR DESCRIPTION
## Summary
- enable running JavaScript from files in the Safari control menu
- handle `run_js_file` entries when replaying recorded sessions
- update tests for new menu layout and add coverage for running JS from files
- document the new menu option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e459d1bc0832aaada446e6e2ae39c