### PR TITLE
Add pytest to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
 
   - repo: local
     hooks:
+      - id: pytest
+        name: Run test suite
+        entry: pytest
+        language: system
+        pass_filenames: false
       - id: alembic-check-heads
         name: Check Alembic Heads
         entry: python scripts/check_alembic_heads.py

--- a/README.md
+++ b/README.md
@@ -159,8 +159,9 @@ Install the pre-commit hooks so formatting and linting run automatically:
 pre-commit install
 ```
 
-The hooks mirror the CI checks, running `ruff check .` and `black --check .` on
-every commit to ensure consistent formatting and linting.
+The hooks mirror the CI checks, running `ruff check .`, `black --check .`, and
+`pytest` on every commit to ensure consistent formatting, linting, and tests
+continue to pass.
 
 Use `python -m auto.cli maintenance update-deps` to upgrade outdated dependencies. Pass `--freeze` to
 rewrite `requirements.txt` after the upgrades.


### PR DESCRIPTION
## Summary
- run `pytest` in the pre-commit configuration
- document the test hook in the README

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: tests/test_replay_continue.py::test_replay_continue)*

------
https://chatgpt.com/codex/tasks/task_e_687e52af0150832a9629032470e09860