### PR TITLE
Use skip env in post form test

### DIFF
--- a/tests/test_post_form.py
+++ b/tests/test_post_form.py
@@ -4,7 +4,8 @@ from auto.models import Post
 from fastapi.testclient import TestClient
 
 
-def test_post_form_insert(test_db_engine):
+def test_post_form_insert(test_db_engine, monkeypatch):
+    monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
     with TestClient(main.app) as client:
         resp = client.get("/posts/new")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- set `SKIP_SLOW_PRINT` when running the post form test

## Testing
- `pytest tests/test_post_form.py::test_post_form_insert -q`

------
https://chatgpt.com/codex/tasks/task_e_687e54f577ec832a8aedf29ac475d1e2