### PR TITLE
Add AppleScript file option to Safari automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,10 @@ For ad-hoc experimentation you can launch an interactive Safari control menu:
 python -m auto.cli automation control-safari
 ```
 
-Alongside opening pages and clicking selectors, the menu now includes a
-"run_js_file" option to execute JavaScript from a file. This makes it easy to
-inject helper functions and call them later.
+Alongside opening pages and clicking selectors, the menu now includes
+"run_js_file" and "run_applescript_file" options to execute code from external
+files. This makes it easy to inject helper functions or run custom AppleScript
+snippets.
 
 ## Running tests
 

--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -279,6 +279,7 @@ def _interactive_menu(
         ("fill", "Fill a selector with text"),
         ("run_js", "Run arbitrary JavaScript"),
         ("run_js_file", "Run JavaScript from a file"),
+        ("run_applescript_file", "Run AppleScript from a file"),
         ("fetch_dom", "Save page DOM to fixture"),
         ("close_tab", "Close the current tab"),
         ("quit", "Exit the menu"),
@@ -331,6 +332,19 @@ def _interactive_menu(
             result = controller.run_js(code)
             if result:
                 print(result)
+        elif choice == "run_applescript_file":
+            path_str = input("AppleScript file path: ")
+            path = Path(path_str)
+            collected.append(["run_applescript_file", path_str])
+            proc = subprocess.run(
+                ["osascript", str(path)], capture_output=True, text=True
+            )
+            if proc.returncode == 0:
+                out = proc.stdout.strip()
+                if out:
+                    print(out)
+            else:
+                print(proc.stderr.strip())
         elif choice == "fetch_dom":
             dom = fetch_dom_html()
             dest = test_dir / f"{step}.html"
@@ -412,6 +426,19 @@ def replay(name: str = "facebook") -> None:
                 controller.run_js(path.read_text())
             else:
                 typer.echo(f"JS file not found: {path}")
+        elif cmd == "run_applescript_file" and args:
+            path = Path(args[0])
+            if path.exists():
+                _slow_print(f"Running AppleScript from {path}")
+                proc = subprocess.run(
+                    ["osascript", str(path)], capture_output=True, text=True
+                )
+                if proc.returncode != 0:
+                    typer.echo(proc.stderr.strip())
+                elif proc.stdout:
+                    typer.echo(proc.stdout.strip())
+            else:
+                typer.echo(f"AppleScript file not found: {path}")
         elif cmd == "close_tab":
             _slow_print("Closing tab")
             controller.close_tab()

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -34,7 +34,7 @@ def test_control_safari(monkeypatch, capsys):
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
 
-    key_inputs = iter(["1", "6", "8"])  # open, fetch_dom, quit
+    key_inputs = iter(["1", "7", "9"])  # open, fetch_dom, quit
     text_inputs = iter(
         [
             "demo_test",
@@ -69,7 +69,7 @@ def test_control_safari_run_js_file(monkeypatch, tmp_path):
     js_code = "console.log('hello');"
     js_path.write_text(js_code)
 
-    key_inputs = iter(["5", "8"])  # run_js_file, quit
+    key_inputs = iter(["5", "9"])  # run_js_file, quit
     text_inputs = iter(
         [
             "demo_js",
@@ -83,3 +83,36 @@ def test_control_safari_run_js_file(monkeypatch, tmp_path):
 
     assert ("run_js", js_code) in controller.calls
     shutil.rmtree(Path("tests/fixtures/demo_js"))
+
+
+def test_control_safari_run_applescript_file(monkeypatch, tmp_path):
+    controller = DummyController()
+    monkeypatch.setattr(tasks, "SafariController", lambda: controller)
+
+    script_path = tmp_path / "helper.scpt"
+    script_path.write_text('say "hello"')
+
+    calls = []
+
+    def fake_run(cmd, capture_output=True, text=True):
+        calls.append(cmd)
+        from subprocess import CompletedProcess
+
+        return CompletedProcess(cmd, 0, stdout="OK", stderr="")
+
+    monkeypatch.setattr(tasks.subprocess, "run", fake_run)
+
+    key_inputs = iter(["6", "9"])  # run_applescript_file, quit
+    text_inputs = iter(
+        [
+            "demo_scpt",
+            str(script_path),
+        ]
+    )
+    monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
+    monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
+
+    tasks.control_safari()
+
+    assert calls == [["osascript", str(script_path)]]
+    shutil.rmtree(Path("tests/fixtures/demo_scpt"))

--- a/tests/test_replay_continue.py
+++ b/tests/test_replay_continue.py
@@ -41,7 +41,7 @@ def test_replay_continue(monkeypatch, tmp_path):
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
     monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
 
-    key_inputs = iter(["6", "8"])  # fetch_dom then quit
+    key_inputs = iter(["7", "9"])  # fetch_dom then quit
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     inputs = iter(["y"])  # continue recording
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))


### PR DESCRIPTION
## Summary
- extend interactive Safari control to run AppleScript files
- allow replaying AppleScript file commands
- document new option
- adjust tests for updated menu and add new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e746caaa8832abfbca19848a68eda