### PR TITLE
Add llm_query to safari control menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,10 @@ python -m auto.cli automation control-safari
 ```
 
 Alongside opening pages and clicking selectors, the menu now includes
-"run_js_file" and "run_applescript_file" options to execute code from external
-files. This makes it easy to inject helper functions or run custom AppleScript
-snippets.
+"run_js_file", "run_applescript_file", and "llm_query" options to execute code
+from external files or query a local LLM. This makes it easy to inject helper
+functions, run custom AppleScript snippets, or save responses from an LLM
+prompt.
 
 ## Running tests
 

--- a/tests/test_replay_continue.py
+++ b/tests/test_replay_continue.py
@@ -41,7 +41,7 @@ def test_replay_continue(monkeypatch, tmp_path):
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
     monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
 
-    key_inputs = iter(["7", "9"])  # fetch_dom then quit
+    key_inputs = iter(["7", "10"])  # fetch_dom then quit
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     inputs = iter(["y"])  # continue recording
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))


### PR DESCRIPTION
## Summary
- add `query_llm` helper using `dspy` and env configuration
- expose new `llm_query` command in the interactive Safari menu
- persist LLM responses to the command log and show them during replay
- document the new option in the README
- update tests and add coverage for `llm_query`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f97421eb0832a8d0b4ced5503862d