### PR TITLE
Support hex input for Safari menu

### DIFF
--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -301,18 +301,22 @@ def _interactive_menu(
         ("quit", "Exit the menu"),
     ]
 
+    hex_keys = "0123456789abcdef"  # menu uses hexadecimal ordering 0-9 then a-f
+
     while True:
         print("\nAvailable commands:")
-        for i, (_, desc) in enumerate(commands, 1):
-            print(f"  {i}. {desc}")
-        print("Select option [1-{}]: ".format(len(commands)), end="", flush=True)
-        choice_idx = _read_key()
+        for i, (_, desc) in enumerate(commands):
+            key = hex_keys[i]
+            print(f"  {key}. {desc}")
+        last_key = hex_keys[len(commands) - 1]
+        print(f"Select option [0-{last_key}]: ", end="", flush=True)
+        choice_idx = _read_key().lower()
         print(choice_idx)  # echo the selected key
-        if not choice_idx.isdigit() or not (1 <= int(choice_idx) <= len(commands)):
+        if choice_idx not in hex_keys[: len(commands)]:
             print("Unknown command")
             continue
 
-        choice, _ = commands[int(choice_idx) - 1]
+        choice, _ = commands[int(choice_idx, 16)]
         if choice == "quit":
             break
         elif choice == "open":
@@ -465,7 +469,7 @@ def replay(name: str = "facebook") -> None:
             _slow_print("Closing tab")
             controller.close_tab()
         elif cmd == "llm_query" and len(args) >= 2:
-            prompt, response = args[0], args[1]
+            response = args[1]
             _slow_print(f"LLM response: {response}")
         elif cmd == "fetch_dom" and args:
             src_path = Path(args[0])

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -34,7 +34,7 @@ def test_control_safari(monkeypatch, capsys):
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
 
-    key_inputs = iter(["1", "7", "10"])  # open, fetch_dom, quit
+    key_inputs = iter(["0", "6", "9"])  # open, fetch_dom, quit
     text_inputs = iter(
         [
             "demo_test",
@@ -69,7 +69,7 @@ def test_control_safari_run_js_file(monkeypatch, tmp_path):
     js_code = "console.log('hello');"
     js_path.write_text(js_code)
 
-    key_inputs = iter(["5", "10"])  # run_js_file, quit
+    key_inputs = iter(["4", "9"])  # run_js_file, quit
     text_inputs = iter(
         [
             "demo_js",
@@ -102,7 +102,7 @@ def test_control_safari_run_applescript_file(monkeypatch, tmp_path):
 
     monkeypatch.setattr(tasks.subprocess, "run", fake_run)
 
-    key_inputs = iter(["6", "10"])  # run_applescript_file, quit
+    key_inputs = iter(["5", "9"])  # run_applescript_file, quit
     text_inputs = iter(
         [
             "demo_scpt",
@@ -123,11 +123,13 @@ def test_control_safari_llm_query(monkeypatch):
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     monkeypatch.setattr(tasks, "query_llm", lambda prompt: "pong")
 
-    key_inputs = iter(["9", "10"])  # llm_query, quit
-    text_inputs = iter([
-        "demo_llm",
-        "ping?",
-    ])
+    key_inputs = iter(["8", "9"])  # llm_query, quit
+    text_inputs = iter(
+        [
+            "demo_llm",
+            "ping?",
+        ]
+    )
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
 

--- a/tests/test_replay_continue.py
+++ b/tests/test_replay_continue.py
@@ -41,7 +41,7 @@ def test_replay_continue(monkeypatch, tmp_path):
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
     monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
 
-    key_inputs = iter(["7", "10"])  # fetch_dom then quit
+    key_inputs = iter(["6", "9"])  # fetch_dom then quit
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     inputs = iter(["y"])  # continue recording
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))


### PR DESCRIPTION
## Summary
- add hexadecimal menu keys
- fix unused variable warning
- update tests for new key ordering

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9a8e7698832a8c910f08976735ab