### PR TITLE
Add abort option to Safari control menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,9 @@ python -m auto.cli automation control-safari
 
 Alongside opening pages and clicking selectors, the menu now includes
 "run_js_file", "run_applescript_file", and "llm_query" options to execute code
-from external files or query a local LLM. This makes it easy to inject helper
-functions, run custom AppleScript snippets, or save responses from an LLM
+from external files or query a local LLM. Use "abort" to exit without saving a
+test, or "quit" to write out the recorded steps. This makes it easy to inject
+helper functions, run custom AppleScript snippets, or save responses from an LLM
 prompt.
 
 ## Running tests

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -139,3 +139,21 @@ def test_control_safari_llm_query(monkeypatch):
     log = json.loads((test_dir / "commands.json").read_text())
     assert log == [["llm_query", "ping?", "pong"]]
     shutil.rmtree(test_dir)
+
+
+def test_control_safari_abort(monkeypatch):
+    controller = DummyController()
+    monkeypatch.setattr(tasks, "SafariController", lambda: controller)
+    monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
+
+    key_inputs = iter(["a"])  # abort
+    text_inputs = iter([
+        "demo_abort",
+    ])
+    monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
+    monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
+
+    tasks.control_safari()
+
+    test_dir = Path("tests/fixtures/demo_abort")
+    assert not test_dir.exists()


### PR DESCRIPTION
## Summary
- allow `_interactive_menu` to signal when a session is aborted
- add `abort` command to the Safari control menu
- update `control_safari` and `replay` commands to respect abort state
- test aborting a session without saving
- document new menu option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9da6d464832aa3618a89135d19ad