### PR TITLE
Add dspy experiment invoke task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -185,6 +185,13 @@ def replay(c, name="facebook"):
 
 
 @task
+def dspy_exp(c):
+    """Run the standalone dspy experiment."""
+
+    c.run("python -m auto.cli automation dspy-experiment", pty=True)
+
+
+@task
 def parse_plan(c):
     """Parse PLAN.md into task files."""
     c.run(

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -147,9 +147,11 @@ def test_control_safari_abort(monkeypatch):
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
 
     key_inputs = iter(["a"])  # abort
-    text_inputs = iter([
-        "demo_abort",
-    ])
+    text_inputs = iter(
+        [
+            "demo_abort",
+        ]
+    )
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
 

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -89,6 +89,7 @@ TEST_CASES = [
         {"name": "twitter"},
         "python -m auto.cli automation replay --name twitter",
     ),
+    (inv.dspy_exp, [], {}, "python -m auto.cli automation dspy-experiment"),
     (
         inv.parse_plan,
         [],


### PR DESCRIPTION
## Summary
- add `dspy_exp` invoke task to run the dspy experiment
- ensure invoke test coverage

## Testing
- `pre-commit run --files tasks.py tests/test_invoke_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_687fafcc15f8832aa07081c91994e58f