### PR TITLE
Use dspy experiment settings in Safari LLM menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ test, or "quit" to write out the recorded steps. This makes it easy to inject
 helper functions, run custom AppleScript snippets, or save responses from an LLM
 prompt.
 
+The ``llm_query`` option uses the same dspy configuration as the ``dspy_exp``
+experiment script, connecting to an Ollama instance running locally.
+
 ## Running tests
 
 Before running tests, install the project dependencies. The

--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -63,14 +63,9 @@ def _next_step(commands: Iterable[list[str]]) -> int:
 def query_llm(prompt: str) -> str:
     """Return the response from a local LLM via dspy."""
 
-    import os
     import dspy
 
-    model = os.getenv("DSPY_MODEL", "gemma-3-27b-it-qat")
-    api_base = os.getenv("DSPY_API_BASE", "http://localhost:1234/v1")
-    model_type = os.getenv("DSPY_MODEL_TYPE", "chat")
-
-    lm = dspy.LM(model=model, api_base=api_base, api_key="", model_type=model_type)
+    lm = dspy.LM("ollama_chat/gemma3:4b", api_base="http://localhost:11434", api_key="")
     dspy.configure(lm=lm)
     return lm(messages=[{"role": "user", "content": prompt}]).strip()
 


### PR DESCRIPTION
## Summary
- configure `llm_query` to match the dspy experiment setup
- document that `llm_query` uses the same configuration as `dspy_exp`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687fb245a9d0832aa136b4a9fe897b3c