### PR TITLE
Fix query_llm output handling

### DIFF
--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -67,7 +67,13 @@ def query_llm(prompt: str) -> str:
 
     lm = dspy.LM("ollama_chat/gemma3:4b", api_base="http://localhost:11434", api_key="")
     dspy.configure(lm=lm)
-    return lm(messages=[{"role": "user", "content": prompt}]).strip()
+
+    response = lm(messages=[{"role": "user", "content": prompt}])
+
+    if isinstance(response, list):
+        response = response[0]
+
+    return str(response).strip()
 
 
 app = typer.Typer(help="Automation commands")

--- a/tests/test_query_llm.py
+++ b/tests/test_query_llm.py
@@ -1,0 +1,14 @@
+import types
+import sys
+from auto.cli.automation import query_llm
+
+class DummyLM:
+    def __call__(self, *args, **kwargs):
+        return ["pong"]
+
+def test_query_llm_handles_list(monkeypatch):
+    dummy = types.ModuleType('dspy')
+    dummy.LM = lambda *args, **kwargs: DummyLM()
+    dummy.configure = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, 'dspy', dummy)
+    assert query_llm("ping") == "pong"


### PR DESCRIPTION
## Summary
- handle list output from dspy in `query_llm`
- add regression test for `query_llm`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb3eae194832aa4f7f697a0c5bde6