### PR TITLE
Add project_root helper and use in modules

### DIFF
--- a/src/auto/automation/safari.py
+++ b/src/auto/automation/safari.py
@@ -1,15 +1,15 @@
 import subprocess
 from pathlib import Path
 
+from ..utils import project_root
+
 
 class SafariController:
     """Control Safari using AppleScript commands."""
 
     def __init__(self, script: Path | None = None) -> None:
         if script is None:
-            script = (
-                Path(__file__).resolve().parents[3] / "scripts" / "safari_control.scpt"
-            )
+            script = project_root() / "scripts" / "safari_control.scpt"
         self.script = script
 
     def _run(self, command: str, *args: str) -> str:

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -10,6 +10,7 @@ from alembic import command
 from dateutil import parser
 from pathlib import Path
 
+from ..utils import project_root
 from contextlib import contextmanager
 from typing import Iterator
 
@@ -24,8 +25,8 @@ from ..config import get_feed_url
 logger = logging.getLogger(__name__)
 
 
-# Determine project root four directories above this file
-BASE_DIR = Path(__file__).resolve().parents[3]
+# Project root directory
+BASE_DIR = project_root()
 DB_PATH = str(BASE_DIR / "substack.db")
 ALEMBIC_INI = BASE_DIR / "alembic.ini"
 

--- a/src/auto/utils/__init__.py
+++ b/src/auto/utils/__init__.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def project_root() -> Path:
+    """Return the root directory of the project."""
+    return Path(__file__).resolve().parents[3]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,17 +6,20 @@ from sqlalchemy import create_engine
 import pytest
 import time
 
-ROOT = Path(__file__).resolve().parents[1]
-SRC = ROOT / "src"
+BASE_ROOT = Path(__file__).resolve().parents[1]
+SRC = BASE_ROOT / "src"
 sys.path.insert(0, str(SRC))
-sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(BASE_ROOT))
+
+from auto.utils import project_root  # noqa: E402
+ROOT = project_root()
 
 from auto.feeds.ingestion import init_db  # noqa: E402
 from auto.db import SessionLocal  # noqa: E402
 
 
 def _check_dependencies() -> None:
-    requirements_file = Path(__file__).resolve().parents[1] / "requirements.txt"
+    requirements_file = ROOT / "requirements.txt"
     missing = []
     for line in requirements_file.read_text().splitlines():
         line = line.strip()


### PR DESCRIPTION
## Summary
- introduce `project_root` helper to centralize repository root detection
- use the helper in `SafariController` and feed ingestion
- update test configuration to rely on `project_root`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb705dfc4832a9130a80f48cc783e