### PR TITLE
Lazily init social plugin registry

### DIFF
--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -7,7 +7,7 @@ from .scheduler import Scheduler
 from . import configure_logging
 from .metrics import router as metrics_router
 from .web_posts import router as posts_router
-from .socials import registry
+from .socials.registry import get_registry
 from .socials.mastodon_client import MastodonClient
 from .socials.medium_client import MediumClient
 import logging
@@ -19,9 +19,9 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     configure_logging()
     init_db()
-    registry.plugins = registry.PluginRegistry()
-    registry.plugins.register(MastodonClient())
-    registry.plugins.register(MediumClient())
+    reg = get_registry()
+    reg.register(MastodonClient())
+    reg.register(MediumClient())
     sched = Scheduler()
     await sched.start()
     try:

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -13,7 +13,7 @@ from sqlalchemy import and_, or_
 from .models import PostStatus, Post, PostPreview, Task
 
 from .db import SessionLocal, get_engine
-from .socials import registry
+from .socials.registry import get_registry
 
 # Temporary alias for tests using the old PLUGINS mapping
 from .metrics import POSTS_PUBLISHED, POSTS_FAILED
@@ -53,9 +53,8 @@ async def _publish(status: PostStatus, session: Session) -> None:
         session.commit()
         return
     try:
-        if registry.plugins is None:
-            raise RuntimeError("Plugin registry not initialized")
-        plugin = registry.plugins.get(status.network)
+        plugin_registry = get_registry()
+        plugin = plugin_registry.get(status.network)
         if plugin is None:
             raise ValueError(f"Unsupported network {status.network}")
         preview = session.get(

--- a/src/auto/socials/registry.py
+++ b/src/auto/socials/registry.py
@@ -18,6 +18,19 @@ class PluginRegistry:
         return self._plugins.get(name)
 
 
-# Global reference to the application's plugin registry. It is created during
-# application startup.
-plugins: PluginRegistry | None = None
+_registry: PluginRegistry | None = None
+
+
+def get_registry() -> PluginRegistry:
+    """Return the application's :class:`PluginRegistry` instance."""
+    global _registry
+    if _registry is None:
+        _registry = PluginRegistry()
+    return _registry
+
+
+def reset_registry() -> None:
+    """Clear the global registry (for tests)."""
+    global _registry
+    _registry = None
+


### PR DESCRIPTION
## Summary
- add `get_registry()` accessor for social plugins
- lazily initialize the plugin registry
- update scheduler and FastAPI app startup to use the accessor
- adjust scheduler tests and add regression test for importing before setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb72d6568832aae0ff7093013045d