### PR TITLE
Fix schedule timezone handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,8 +23,6 @@
 - Share a single logging setup between the main app and plan executor.
 
 ## BUGS
-- `schedule()` stores naive datetimes when no timezone is supplied, leading to
-  inconsistent scheduling.
 
 ## RECS
 - Add a CLI wrapper for common tasks like listing posts or scheduling to reduce reliance on Invoke.

--- a/src/auto/cli/publish.py
+++ b/src/auto/cli/publish.py
@@ -85,6 +85,10 @@ def schedule(post_id: str, time: str, network: Optional[str] = None) -> None:
     """Schedule a post for publishing."""
 
     scheduled_at = _parse_when(time)
+    if scheduled_at.tzinfo is None:
+        scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+    else:
+        scheduled_at = scheduled_at.astimezone(timezone.utc)
     networks = [network] if network else ["mastodon"]
 
     with SessionLocal() as session:


### PR DESCRIPTION
## Summary
- ensure schedule timestamps are stored in UTC
- remove completed bug item from TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbe59bf7c832aa953a73181fdda8a