### PR TITLE
Add trending tags support for previews

### DIFF
--- a/docs/previews.md
+++ b/docs/previews.md
@@ -16,6 +16,15 @@ python -m auto.cli publish generate-preview --post-id <id> --network mastodon
 
 This fetches the post from the database and creates or updates a row in `post_previews`. When `--use-llm` is provided, a local LLM is used to craft the text; otherwise a simple template is stored.
 
+Additional context can be supplied with `--notes` and `--tags-limit` to
+include free‑form notes or the names of trending tags in the prompt. For
+example:
+
+```bash
+python -m auto.cli publish generate-preview --post-id <id> \
+    --notes "Check analytics" --tags-limit 3 --use-llm
+```
+
 ### Scheduling Generation
 
 Instead of generating the preview immediately, you can create a `create_preview` task:

--- a/src/auto/cli/publish.py
+++ b/src/auto/cli/publish.py
@@ -232,6 +232,8 @@ def create_preview(
 def generate_preview(
     post_id: str,
     network: str = "mastodon",
+    notes: Optional[str] = None,
+    tags_limit: int = 0,
     use_llm: bool = False,
     model: str = "gemma-3-27b-it-qat",
     api_base: str = "http://localhost:1234/v1",
@@ -245,6 +247,8 @@ def generate_preview(
                 session,
                 post_id,
                 network,
+                notes=notes,
+                tags_limit=tags_limit,
                 use_llm=use_llm,
                 model=model,
                 api_base=api_base,

--- a/src/auto/plan/types.py
+++ b/src/auto/plan/types.py
@@ -26,6 +26,10 @@ class Step:
     url: Optional[str] = None
     selector: Optional[str] = None
     prompt_template: Optional[str] = None
+    post_id: Optional[str] = None
+    network: str = "mastodon"
+    notes: Optional[str] = None
+    tags_limit: int = 0
     store_as: Optional[str] = None
     status: str = "pending"  # pending | success | failed | abandoned
     result: Optional[str] = None  # log of what happened

--- a/src/auto/socials/mastodon_client.py
+++ b/src/auto/socials/mastodon_client.py
@@ -1,13 +1,33 @@
 import asyncio
 import anyio
 import logging
-from typing import Dict
+from typing import Dict, List
 import httpx
 
 from .base import SocialPlugin
 from ..config import get_mastodon_instance, get_mastodon_token
 
 logger = logging.getLogger(__name__)
+
+
+def fetch_trending_tags(limit: int = 10) -> List[str]:
+    """Return a list of trending tag names from Mastodon."""
+    from mastodon import Mastodon
+
+    instance = get_mastodon_instance()
+    token = get_mastodon_token()
+
+    try:
+        masto = Mastodon(access_token=token, api_base_url=instance)
+        tags = masto.trending_tags(limit=limit)
+        names = [
+            tag["name"] if isinstance(tag, dict) else getattr(tag, "name", str(tag))
+            for tag in tags
+        ]
+        return names
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.error("Failed to fetch trending tags: %s", exc)
+        return []
 
 
 class MastodonClient(SocialPlugin):


### PR DESCRIPTION
## Summary
- allow preview generation to include custom notes and trending tags
- fetch trending tags from Mastodon
- support `compose_post` step in automation plans
- document the new preview options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fb6fa28d4832a8ac6c6d3d41371a8