### PR TITLE
Add compose_post step

### DIFF
--- a/src/auto/plan/types.py
+++ b/src/auto/plan/types.py
@@ -26,6 +26,10 @@ class Step:
     url: Optional[str] = None
     selector: Optional[str] = None
     prompt_template: Optional[str] = None
+    post_id: Optional[str] = None
+    network: Optional[str] = None
+    preview_var: Optional[str] = None
+    tags_var: Optional[str] = None
     store_as: Optional[str] = None
     status: str = "pending"  # pending | success | failed | abandoned
     result: Optional[str] = None  # log of what happened

--- a/tests/test_compose_post.py
+++ b/tests/test_compose_post.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timezone
+
+from auto.automation.plan_executor import StepExecutor
+from auto.plan.types import Step
+from auto.models import Post, PostPreview, PostStatus
+
+
+class DummySafari:
+    def __init__(self):
+        self.calls = []
+
+    def open(self, url):
+        self.calls.append(("open", url))
+        return "OK"
+
+    def click(self, selector):
+        self.calls.append(("click", selector))
+        return "OK"
+
+    def fill(self, selector, text):
+        self.calls.append(("fill", selector, text))
+        return "OK"
+
+    def run_js(self, code):
+        self.calls.append(("run_js", code))
+        return "<html></html>"
+
+    def close_tab(self):
+        self.calls.append(("close_tab",))
+        return "OK"
+
+
+def test_compose_post_step(session, tmp_path):
+    # create post, status and preview
+    post = Post(id="1", title="Title", link="http://example", summary="", published="")
+    status = PostStatus(post_id="1", network="mastodon", scheduled_at=datetime.now(timezone.utc))
+    preview = PostPreview(
+        post_id="1", network="mastodon", content="{{ post.title }} {{ post.link }}"
+    )
+    session.add_all([post, status, preview])
+    session.commit()
+
+    step = Step(id=1, type="compose_post", post_id="1", network="mastodon", tags_var="tags", store_as="final")
+    executor = StepExecutor(controller=DummySafari(), snapshot_dir=tmp_path)
+    executor.variables["tags"] = ["#python", "#coding"]
+
+    updated = executor.execute(step)
+
+    assert updated.status == "success"
+    assert executor.variables["final"] == "Title http://example #python #coding"


### PR DESCRIPTION
## Summary
- extend Step data model with fields for composing posts
- implement new `compose_post` step in `StepExecutor`
- test composing post text

## Testing
- `pytest tests/test_compose_post.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc156dc98832a8a3620cadfcb5ef3