### PR TITLE
Handle variables when replaying fixtures

### DIFF
--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -34,7 +34,7 @@ def test_control_safari(monkeypatch, capsys):
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
 
-    key_inputs = iter(["0", "6", "9"])  # open, fetch_dom, quit
+    key_inputs = iter(["0", "6", "a"])  # open, fetch_dom, quit
     text_inputs = iter(
         [
             "demo_test",
@@ -69,7 +69,7 @@ def test_control_safari_run_js_file(monkeypatch, tmp_path):
     js_code = "console.log('hello');"
     js_path.write_text(js_code)
 
-    key_inputs = iter(["4", "9"])  # run_js_file, quit
+    key_inputs = iter(["4", "a"])  # run_js_file, quit
     text_inputs = iter(
         [
             "demo_js",
@@ -102,7 +102,7 @@ def test_control_safari_run_applescript_file(monkeypatch, tmp_path):
 
     monkeypatch.setattr(tasks.subprocess, "run", fake_run)
 
-    key_inputs = iter(["5", "9"])  # run_applescript_file, quit
+    key_inputs = iter(["5", "a"])  # run_applescript_file, quit
     text_inputs = iter(
         [
             "demo_scpt",
@@ -123,11 +123,12 @@ def test_control_safari_llm_query(monkeypatch):
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     monkeypatch.setattr(tasks, "query_llm", lambda prompt: "pong")
 
-    key_inputs = iter(["8", "9"])  # llm_query, quit
+    key_inputs = iter(["8", "a"])  # llm_query, quit
     text_inputs = iter(
         [
             "demo_llm",
             "ping?",
+            "answer",
         ]
     )
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
@@ -137,7 +138,7 @@ def test_control_safari_llm_query(monkeypatch):
 
     test_dir = Path("tests/fixtures/demo_llm")
     log = json.loads((test_dir / "commands.json").read_text())
-    assert log == [["llm_query", "ping?", "pong"]]
+    assert log == [["llm_query", "ping?", "pong", "answer"]]
     shutil.rmtree(test_dir)
 
 
@@ -146,7 +147,7 @@ def test_control_safari_abort(monkeypatch):
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
 
-    key_inputs = iter(["a"])  # abort
+    key_inputs = iter(["b"])  # abort
     text_inputs = iter(
         [
             "demo_abort",

--- a/tests/test_replay_continue.py
+++ b/tests/test_replay_continue.py
@@ -41,7 +41,7 @@ def test_replay_continue(monkeypatch, tmp_path):
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
     monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
 
-    key_inputs = iter(["6", "9"])  # fetch_dom then quit
+    key_inputs = iter(["6", "a"])  # fetch_dom then quit
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     inputs = iter(["y"])  # continue recording
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))


### PR DESCRIPTION
## Summary
- extend interactive Safari menu with variable storage and inspection
- ask for a `store_as` name after LLM queries and record it
- support variables when replaying recorded commands
- update tests for new menu layout and behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd265ba30832aad20c052b3b36cd5