### PR TITLE
Fix invoke preview commands

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,7 @@ def list_schedule(c):
 def generate_preview(c, post_id, network="mastodon"):
     """Generate or update a preview for ``post_id``."""
     c.run(
-        f"python -m auto.cli publish generate-preview --post-id {post_id} --network {network}",
+        f"python -m auto.cli publish generate-preview {post_id} --network {network}",
         pty=True,
     )
 
@@ -92,7 +92,7 @@ def create_preview(c, post_id, network="mastodon", when=None, dry_run=False):
     when_flag = f"--when {when}" if when else ""
     dry_flag = "--dry-run" if dry_run else ""
     c.run(
-        f"python -m auto.cli publish create-preview --post-id {post_id} --network {network} {when_flag} {dry_flag}",
+        f"python -m auto.cli publish create-preview {post_id} --network {network} {when_flag} {dry_flag}",
         pty=True,
     )
 
@@ -106,7 +106,7 @@ def create_preview(c, post_id, network="mastodon", when=None, dry_run=False):
 def edit_preview(c, post_id, network="mastodon"):
     """Interactively edit a stored preview."""
     c.run(
-        f"python -m auto.cli publish edit-preview --post-id {post_id} --network {network}",
+        f"python -m auto.cli publish edit-preview {post_id} --network {network}",
         pty=True,
     )
 

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -37,19 +37,19 @@ TEST_CASES = [
         inv.generate_preview,
         [123],
         {},
-        "python -m auto.cli publish generate-preview --post-id 123 --network mastodon",
+        "python -m auto.cli publish generate-preview 123 --network mastodon",
     ),
     (
         inv.create_preview,
         [123],
         {"when": "now", "dry_run": True},
-        "python -m auto.cli publish create-preview --post-id 123 --network mastodon --when now --dry-run",
+        "python -m auto.cli publish create-preview 123 --network mastodon --when now --dry-run",
     ),
     (
         inv.edit_preview,
         [123],
         {"network": "twitter"},
-        "python -m auto.cli publish edit-preview --post-id 123 --network twitter",
+        "python -m auto.cli publish edit-preview 123 --network twitter",
     ),
     (
         inv.trending_tags,


### PR DESCRIPTION
## Summary
- fix invocation to call Typer CLI using positional argument for post ID
- update tests to match the corrected CLI commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd4eb4758832ab5ced23fc6a268eb