### PR TITLE
Support templated Safari fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ prompt.
 The ``llm_query`` option uses the same dspy configuration as the ``dspy_exp``
 experiment script, connecting to an Ollama instance running locally.
 
+Recorded command files may contain Jinja2 placeholders. When used in a plan
+step of type ``run_fixture``, variables provided by the step are substituted
+before replaying the commands. This enables developing a literal flow first and
+later parameterizing values.
+
 ## Running tests
 
 Before running tests, install the project dependencies. The

--- a/src/auto/automation/fixtures.py
+++ b/src/auto/automation/fixtures.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+from typing import Mapping, Any
+from jinja2 import Template
+
+
+def load_commands(
+    name: str,
+    *,
+    variables: Mapping[str, Any] | None = None,
+    root: Path | None = None,
+) -> list[list[str]]:
+    """Return commands for ``name`` rendered with ``variables``."""
+
+    if root is None:
+        root = Path(__file__).resolve().parents[3] / "tests" / "fixtures"
+    path = root / name / "commands.json"
+    data: list[list[str]] = json.loads(path.read_text())
+    if not variables:
+        return data
+
+    rendered: list[list[str]] = []
+    for entry in data:
+        rendered_entry: list[str] = []
+        for val in entry:
+            if isinstance(val, str):
+                rendered_entry.append(Template(val).render(**variables))
+            else:
+                rendered_entry.append(val)
+        rendered.append(rendered_entry)
+    return rendered

--- a/src/auto/plan/types.py
+++ b/src/auto/plan/types.py
@@ -9,7 +9,7 @@ import subprocess
 from dataclasses import dataclass, asdict, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Any
 
 import logging
 
@@ -26,6 +26,8 @@ class Step:
     url: Optional[str] = None
     selector: Optional[str] = None
     prompt_template: Optional[str] = None
+    fixture: Optional[str] = None
+    vars: dict[str, Any] = field(default_factory=dict)
     store_as: Optional[str] = None
     status: str = "pending"  # pending | success | failed | abandoned
     result: Optional[str] = None  # log of what happened

--- a/tests/fixtures/param/commands.json
+++ b/tests/fixtures/param/commands.json
@@ -1,0 +1,4 @@
+[
+  ["open", "https://example.com/{{path}}"],
+  ["click", "{{selector}}"]
+]

--- a/tests/test_fixture_templates.py
+++ b/tests/test_fixture_templates.py
@@ -1,0 +1,49 @@
+from auto.automation.plan_executor import StepExecutor
+from auto.plan.types import Step
+from auto.automation.safari import SafariController
+from auto.automation.fixtures import load_commands
+
+
+class DummyController:
+    def __init__(self):
+        self.calls = []
+
+    def open(self, url):
+        self.calls.append(("open", url))
+
+    def click(self, sel):
+        self.calls.append(("click", sel))
+
+    def fill(self, sel, text):
+        self.calls.append(("fill", sel, text))
+
+    def run_js(self, code):
+        self.calls.append(("run_js", code))
+
+    def close_tab(self):
+        self.calls.append(("close_tab",))
+
+
+def test_load_commands_with_vars(tmp_path):
+    cmds = load_commands("param", variables={"path": "foo", "selector": "#btn"})
+    assert cmds[0][1] == "https://example.com/foo"
+    assert cmds[1][1] == "#btn"
+
+
+def test_run_fixture(monkeypatch):
+    controller = DummyController()
+    monkeypatch.setattr(SafariController, "__init__", lambda self: None)
+    monkeypatch.setattr(SafariController, "open", controller.open)
+    monkeypatch.setattr(SafariController, "click", controller.click)
+    exec = StepExecutor(controller=SafariController())
+    step = Step(
+        id=1,
+        type="run_fixture",
+        fixture="param",
+        vars={"path": "foo", "selector": "#btn"},
+    )
+    exec.execute(step)
+    assert controller.calls == [
+        ("open", "https://example.com/foo"),
+        ("click", "#btn"),
+    ]

--- a/tests/test_query_llm.py
+++ b/tests/test_query_llm.py
@@ -2,13 +2,15 @@ import types
 import sys
 from auto.cli.automation import query_llm
 
+
 class DummyLM:
     def __call__(self, *args, **kwargs):
         return ["pong"]
 
+
 def test_query_llm_handles_list(monkeypatch):
-    dummy = types.ModuleType('dspy')
+    dummy = types.ModuleType("dspy")
     dummy.LM = lambda *args, **kwargs: DummyLM()
     dummy.configure = lambda *args, **kwargs: None
-    monkeypatch.setitem(sys.modules, 'dspy', dummy)
+    monkeypatch.setitem(sys.modules, "dspy", dummy)
     assert query_llm("ping") == "pong"


### PR DESCRIPTION
## Summary
- add helper to render fixture commands with Jinja2
- allow `Step` objects to specify `fixture` and `vars`
- extend `StepExecutor` with `run_fixture` step type and template rendering
- document new fixture templating
- add example fixture and tests for variable substitution

## Testing
- `pre-commit run --files README.md src/auto/automation/plan_executor.py src/auto/automation/fixtures.py src/auto/plan/types.py tests/test_fixture_templates.py tests/fixtures/param/commands.json`
- `pytest tests/test_fixture_templates.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb5a13c24832a9238c599dbdedd68