### PR TITLE
Add invoke task for scheduling posts

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -67,6 +67,21 @@ def list_schedule(c):
 
 @task(
     help={
+        "post_id": "ID of the post to schedule",
+        "when": "Publish time (e.g. '+10m' or ISO timestamp)",
+        "network": "Target social network (default: mastodon)",
+    }
+)
+def schedule(c, post_id, when, network="mastodon"):
+    """Schedule a post for publishing."""
+    c.run(
+        f"python -m auto.cli publish schedule {post_id} {when} --network {network}",
+        pty=True,
+    )
+
+
+@task(
+    help={
         "post_id": "ID of the post to generate a preview for",
         "network": "Target social network (default: mastodon)",
     }

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -34,6 +34,12 @@ TEST_CASES = [
     ),
     (inv.list_schedule, [], {}, "python -m auto.cli publish list-schedule"),
     (
+        inv.schedule,
+        ["123", "+5m"],
+        {"network": "medium"},
+        "python -m auto.cli publish schedule 123 +5m --network medium",
+    ),
+    (
         inv.generate_preview,
         [123],
         {},


### PR DESCRIPTION
## Summary
- add a `schedule` Invoke task as a wrapper for `python -m auto.cli publish schedule`
- cover the new task in the Invoke tasks test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd94f23e0832aac41814c4c0e4ec7