### PR TITLE
Enable variable interpolation in Safari automation menu

### DIFF
--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -85,6 +85,30 @@ def test_control_safari_run_js_file(monkeypatch, tmp_path):
     shutil.rmtree(Path("tests/fixtures/demo_js"))
 
 
+def test_control_safari_run_js_file_with_variable(monkeypatch, tmp_path):
+    controller = DummyController()
+    monkeypatch.setattr(tasks, "SafariController", lambda: controller)
+    monkeypatch.setattr(tasks, "query_llm", lambda prompt: "42")
+
+    js_path = tmp_path / "helper.js"
+    js_path.write_text("console.log({{num}});")
+
+    key_inputs = iter(["8", "4", "a"])  # llm_query, run_js_file, quit
+    text_inputs = iter([
+        "demo_js_var",
+        "meaning?",
+        "num",
+        str(js_path),
+    ])
+    monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
+    monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
+
+    tasks.control_safari()
+
+    assert ("run_js", "console.log(42);") in controller.calls
+    shutil.rmtree(Path("tests/fixtures/demo_js_var"))
+
+
 def test_control_safari_run_applescript_file(monkeypatch, tmp_path):
     controller = DummyController()
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
@@ -114,8 +138,42 @@ def test_control_safari_run_applescript_file(monkeypatch, tmp_path):
 
     tasks.control_safari()
 
-    assert calls == [["osascript", str(script_path)]]
+    assert calls and calls[0][0] == "osascript"
     shutil.rmtree(Path("tests/fixtures/demo_scpt"))
+
+
+def test_control_safari_run_applescript_file_with_variable(monkeypatch, tmp_path):
+    controller = DummyController()
+    monkeypatch.setattr(tasks, "SafariController", lambda: controller)
+    monkeypatch.setattr(tasks, "query_llm", lambda prompt: "hi")
+
+    script_path = tmp_path / "helper.scpt"
+    script_path.write_text('say "{{word}}"')
+
+    outputs = []
+
+    def fake_run(cmd, capture_output=True, text=True):
+        content = Path(cmd[1]).read_text()
+        outputs.append(content)
+        from subprocess import CompletedProcess
+        return CompletedProcess(cmd, 0, stdout="OK", stderr="")
+
+    monkeypatch.setattr(tasks.subprocess, "run", fake_run)
+
+    key_inputs = iter(["8", "5", "a"])  # llm_query, run_applescript_file, quit
+    text_inputs = iter([
+        "demo_scpt_var",
+        "hello?",
+        "word",
+        str(script_path),
+    ])
+    monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
+    monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
+
+    tasks.control_safari()
+
+    assert outputs and outputs[0] == 'say "hi"'
+    shutil.rmtree(Path("tests/fixtures/demo_scpt_var"))
 
 
 def test_control_safari_llm_query(monkeypatch):
@@ -139,6 +197,33 @@ def test_control_safari_llm_query(monkeypatch):
     test_dir = Path("tests/fixtures/demo_llm")
     log = json.loads((test_dir / "commands.json").read_text())
     assert log == [["llm_query", "ping?", "pong", "answer"]]
+    shutil.rmtree(test_dir)
+
+
+def test_control_safari_fill_with_variable(monkeypatch):
+    controller = DummyController()
+    monkeypatch.setattr(tasks, "SafariController", lambda: controller)
+    monkeypatch.setattr(tasks, "query_llm", lambda prompt: "hello")
+
+    key_inputs = iter(["8", "2", "a"])  # llm_query, fill, quit
+    text_inputs = iter(
+        [
+            "demo_fill_var",
+            "ping",
+            "msg",
+            "#box",
+            "{{msg}}",
+        ]
+    )
+    monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
+    monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
+
+    tasks.control_safari()
+
+    assert ("fill", "#box", "hello") in controller.calls
+    test_dir = Path("tests/fixtures/demo_fill_var")
+    log = json.loads((test_dir / "commands.json").read_text())
+    assert log == [["llm_query", "ping", "hello", "msg"], ["fill", "#box", "{{msg}}"]]
     shutil.rmtree(test_dir)
 
 


### PR DESCRIPTION
## Summary
- allow referencing stored variables in interactive Safari automation commands
- handle variable templates in JS and AppleScript files via jinja2
- exercise new behavior in safari control tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fdba1c180832ab6106e33a9fbca10