### PR TITLE
Implement template-based preview generation

### DIFF
--- a/docs/previews.md
+++ b/docs/previews.md
@@ -14,7 +14,12 @@ Run the `generate-preview` command with the post ID and network:
 python -m auto.cli publish generate-preview --post-id <id> --network mastodon
 ```
 
-This fetches the post from the database and creates or updates a row in `post_previews`. When `--use-llm` is provided, a local LLM is used to craft the text; otherwise a simple template is stored.
+This fetches the post from the database and generates a preview. The text sent
+to the LLM is loaded from the file specified by the `PREVIEW_TEMPLATE_PATH`
+environment variable or `src/auto/templates/preview_prompt.txt` by default. The
+previous preview is removed before the new one is saved. When `--use-llm` is
+provided, a local LLM creates the summary; otherwise the post title or summary
+is used.
 
 ### Scheduling Generation
 

--- a/src/auto/feeds/ingestion.py
+++ b/src/auto/feeds/ingestion.py
@@ -8,8 +8,6 @@ from bs4 import BeautifulSoup
 from alembic.config import Config
 from alembic import command
 from dateutil import parser
-from pathlib import Path
-
 from ..utils import project_root
 from contextlib import contextmanager
 from typing import Iterator
@@ -199,11 +197,7 @@ def save_entries(items, db_path=DB_PATH, *, engine=None, session_factory=None):
                     logger.info("Saved post: %s", title)
                 except IntegrityError:
                     existing = session.get(Post, guid)
-                    if (
-                        existing is not None
-                        and not existing.content
-                        and content
-                    ):
+                    if existing is not None and not existing.content and content:
                         existing.content = content
                         logger.info("Backfilled post: %s", title)
                     else:

--- a/src/auto/templates/preview_prompt.txt
+++ b/src/auto/templates/preview_prompt.txt
@@ -1,0 +1,3 @@
+Summarize the following post in one short paragraph:
+
+{{ content }}

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timezone
+
+from auto.preview import create_preview
+from auto.models import Post, PostStatus, PostPreview
+
+
+def test_create_preview_replaces(session, tmp_path):
+    post = Post(
+        id="p1",
+        title="Title",
+        link="http://example",
+        content="Content",
+        summary="",
+        published="",
+    )
+    status = PostStatus(
+        post_id="p1", network="mastodon", scheduled_at=datetime.now(timezone.utc)
+    )
+    session.add_all([post, status])
+    session.commit()
+
+    template = tmp_path / "tmpl.txt"
+    template.write_text("Summary:\n{{ content }}")
+
+    create_preview(session, "p1", "mastodon", template_path=str(template))
+
+    first = session.get(PostPreview, {"post_id": "p1", "network": "mastodon"})
+    assert first is not None
+    template.write_text("Updated:\n{{ content }}")
+    create_preview(session, "p1", "mastodon", template_path=str(template))
+
+    second = session.get(PostPreview, {"post_id": "p1", "network": "mastodon"})
+    assert second is not None
+    assert session.query(PostPreview).count() == 1


### PR DESCRIPTION
## Summary
- add preview_prompt template
- expand `create_preview` with template loading and deletion logic
- document `PREVIEW_TEMPLATE_PATH`
- ensure previous preview is replaced when regenerated
- add regression test for preview replacement

## Testing
- `pre-commit run --files src/auto/preview.py src/auto/templates/preview_prompt.txt docs/previews.md tests/test_preview.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe09af874832a930c6f1f1771020a