### PR TITLE
Harmonize LLM usage with dspy

### DIFF
--- a/src/auto/automation/retro_planner.py
+++ b/src/auto/automation/retro_planner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from openai import OpenAI
+from typing import Any
 
 from ..plan.logging import ExecutionLogger
 from ..plan.types import Plan, PlanManager, Step
@@ -13,7 +13,7 @@ class RetroPlanner:
     """Simple planner that can regenerate a plan using an LLM."""
 
     def __init__(
-        self, llm_client: OpenAI, log_store: ExecutionLogger, pm: PlanManager
+        self, llm_client: Any, log_store: ExecutionLogger, pm: PlanManager
     ) -> None:
         self.llm = llm_client
         self.log_store = log_store
@@ -36,7 +36,7 @@ class RetroPlanner:
     def replan(self, plan: Plan) -> Plan:
         prompt = self._build_prompt(plan)
         try:
-            response = self.llm.complete(prompt)
+            response = self.llm(messages=[{"role": "user", "content": prompt}])
         except Exception as exc:
             logger.warning("LLM replanning failed: %s", exc)
             return plan

--- a/src/auto/automation/supervisor.py
+++ b/src/auto/automation/supervisor.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 
-from openai import OpenAI
+import dspy
 from ..utils.periodic import PeriodicWorker
 
 from ..plan.logging import ExecutionLogger, MemoryModule
@@ -26,7 +26,11 @@ class Supervisor:
         self.pm = PlanManager("plan.json")
         self.el = ExecutionLogger("execution_log.json")
         self.mm = MemoryModule("memory.json")
-        self.rp = RetroPlanner(llm_client=OpenAI(), log_store=self.el, pm=self.pm)
+        lm = dspy.LM(
+            "ollama_chat/gemma3:4b", api_base="http://localhost:11434", api_key=""
+        )
+        dspy.configure(lm=lm)
+        self.rp = RetroPlanner(llm_client=lm, log_store=self.el, pm=self.pm)
         self._last_check = datetime.min.replace(tzinfo=timezone.utc)
         self._worker = PeriodicWorker(self._step, 1)
 

--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -378,14 +378,20 @@ def _interactive_menu(
             collected.append(["run_applescript_file", path_str])
             code = path.read_text()
             rendered = _render(code)
-            import tempfile, os
+            import tempfile
+            import os
+
             with tempfile.NamedTemporaryFile("w", suffix=".scpt", delete=False) as tmp:
                 tmp.write(rendered)
                 temp_path = tmp.name
-            proc = subprocess.run([
-                "osascript",
-                temp_path,
-            ], capture_output=True, text=True)
+            proc = subprocess.run(
+                [
+                    "osascript",
+                    temp_path,
+                ],
+                capture_output=True,
+                text=True,
+            )
             os.unlink(temp_path)
             if proc.returncode == 0:
                 out = proc.stdout.strip()

--- a/src/auto/socials/registry.py
+++ b/src/auto/socials/registry.py
@@ -33,4 +33,3 @@ def reset_registry() -> None:
     """Clear the global registry (for tests)."""
     global _registry
     _registry = None
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(SRC))
 sys.path.insert(0, str(BASE_ROOT))
 
 from auto.utils import project_root  # noqa: E402
+
 ROOT = project_root()
 
 from auto.feeds.ingestion import init_db  # noqa: E402

--- a/tests/test_compose_post.py
+++ b/tests/test_compose_post.py
@@ -33,14 +33,23 @@ class DummySafari:
 def test_compose_post_step(session, tmp_path):
     # create post, status and preview
     post = Post(id="1", title="Title", link="http://example", summary="", published="")
-    status = PostStatus(post_id="1", network="mastodon", scheduled_at=datetime.now(timezone.utc))
+    status = PostStatus(
+        post_id="1", network="mastodon", scheduled_at=datetime.now(timezone.utc)
+    )
     preview = PostPreview(
         post_id="1", network="mastodon", content="{{ post.title }} {{ post.link }}"
     )
     session.add_all([post, status, preview])
     session.commit()
 
-    step = Step(id=1, type="compose_post", post_id="1", network="mastodon", tags_var="tags", store_as="final")
+    step = Step(
+        id=1,
+        type="compose_post",
+        post_id="1",
+        network="mastodon",
+        tags_var="tags",
+        store_as="final",
+    )
     executor = StepExecutor(controller=DummySafari(), snapshot_dir=tmp_path)
     executor.variables["tags"] = ["#python", "#coding"]
 

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -94,12 +94,14 @@ def test_control_safari_run_js_file_with_variable(monkeypatch, tmp_path):
     js_path.write_text("console.log({{num}});")
 
     key_inputs = iter(["8", "4", "a"])  # llm_query, run_js_file, quit
-    text_inputs = iter([
-        "demo_js_var",
-        "meaning?",
-        "num",
-        str(js_path),
-    ])
+    text_inputs = iter(
+        [
+            "demo_js_var",
+            "meaning?",
+            "num",
+            str(js_path),
+        ]
+    )
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
 
@@ -156,17 +158,20 @@ def test_control_safari_run_applescript_file_with_variable(monkeypatch, tmp_path
         content = Path(cmd[1]).read_text()
         outputs.append(content)
         from subprocess import CompletedProcess
+
         return CompletedProcess(cmd, 0, stdout="OK", stderr="")
 
     monkeypatch.setattr(tasks.subprocess, "run", fake_run)
 
     key_inputs = iter(["8", "5", "a"])  # llm_query, run_applescript_file, quit
-    text_inputs = iter([
-        "demo_scpt_var",
-        "hello?",
-        "word",
-        str(script_path),
-    ])
+    text_inputs = iter(
+        [
+            "demo_scpt_var",
+            "hello?",
+            "word",
+            str(script_path),
+        ]
+    )
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
 

--- a/tests/test_ingest_backfill.py
+++ b/tests/test_ingest_backfill.py
@@ -14,7 +14,13 @@ def test_ingest_backfills_existing_posts(test_db_engine):
         for it in items:
             guid = it.find("guid").text
             session.add(
-                Post(id=guid, title=f"t{guid}", link=f"http://{guid}", summary="", published="")
+                Post(
+                    id=guid,
+                    title=f"t{guid}",
+                    link=f"http://{guid}",
+                    summary="",
+                    published="",
+                )
             )
         session.commit()
 

--- a/tests/test_query_llm.py
+++ b/tests/test_query_llm.py
@@ -2,13 +2,15 @@ import types
 import sys
 from auto.cli.automation import query_llm
 
+
 class DummyLM:
     def __call__(self, *args, **kwargs):
         return ["pong"]
 
+
 def test_query_llm_handles_list(monkeypatch):
-    dummy = types.ModuleType('dspy')
+    dummy = types.ModuleType("dspy")
     dummy.LM = lambda *args, **kwargs: DummyLM()
     dummy.configure = lambda *args, **kwargs: None
-    monkeypatch.setitem(sys.modules, 'dspy', dummy)
+    monkeypatch.setitem(sys.modules, "dspy", dummy)
     assert query_llm("ping") == "pong"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -84,9 +84,13 @@ def test_import_before_plugin_setup(test_db_engine, monkeypatch):
     DummyPoster.called = False
 
     with SessionLocal() as session:
-        post = Post(id="4", title="T4", link="http://example4", summary="", published="")
+        post = Post(
+            id="4", title="T4", link="http://example4", summary="", published=""
+        )
         session.add(post)
-        status = PostStatus(post_id="4", network="mastodon", scheduled_at=datetime.now(timezone.utc))
+        status = PostStatus(
+            post_id="4", network="mastodon", scheduled_at=datetime.now(timezone.utc)
+        )
         session.add(status)
         task = Task(
             type="publish_post",

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,4 +1,6 @@
 import asyncio
+import sys
+import types
 from datetime import datetime, timezone, timedelta
 
 from auto.automation import supervisor
@@ -44,7 +46,10 @@ def test_supervisor_start_stop(monkeypatch):
     monkeypatch.setattr(supervisor, "ExecutionLogger", lambda *a, **k: el)
     monkeypatch.setattr(supervisor, "MemoryModule", lambda *a, **k: mm)
     monkeypatch.setattr(supervisor, "RetroPlanner", lambda *a, **k: rp)
-    monkeypatch.setattr(supervisor, "OpenAI", lambda *a, **k: object())
+    dummy_dspy = types.ModuleType("dspy")
+    dummy_dspy.LM = lambda *a, **k: object()
+    dummy_dspy.configure = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "dspy", dummy_dspy)
 
     sup = supervisor.Supervisor()
     sup._last_check = (


### PR DESCRIPTION
## Summary
- replace OpenAI-based code paths with `dspy` helpers
- create the LM via `dspy.LM` and configure globally
- adjust supervisor tests for the new LLM interface
- run formatting

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffaf8903c832abc1ecf6daa33ce39