### PR TITLE
Add post_id option for dspy experiment

### DIFF
--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -100,10 +100,13 @@ def chat(
 
 
 @app.command()
-def dspy_experiment() -> None:
+def dspy_experiment(post_id: Optional[int] = None) -> None:
     """Run the standalone dspy experiment script."""
 
-    subprocess.run(["python", "src/experiments/dspy_exp.py"], check=True)
+    cmd = ["python", "src/experiments/dspy_exp.py"]
+    if post_id is not None:
+        cmd += ["--post-id", str(post_id)]
+    subprocess.run(cmd, check=True)
 
 
 @app.command()

--- a/tasks.py
+++ b/tasks.py
@@ -199,11 +199,14 @@ def replay(c, name="facebook"):
     c.run(cmd, pty=True)
 
 
-@task
-def dspy_exp(c):
+@task(help={"post_id": "ID of the post to summarize"})
+def dspy_exp(c, post_id):
     """Run the standalone dspy experiment."""
 
-    c.run("python -m auto.cli automation dspy-experiment", pty=True)
+    c.run(
+        f"python -m auto.cli automation dspy-experiment --post-id {post_id}",
+        pty=True,
+    )
 
 
 @task

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -95,7 +95,12 @@ TEST_CASES = [
         {"name": "twitter"},
         "python -m auto.cli automation replay --name twitter",
     ),
-    (inv.dspy_exp, [], {}, "python -m auto.cli automation dspy-experiment"),
+    (
+        inv.dspy_exp,
+        [123],
+        {},
+        "python -m auto.cli automation dspy-experiment --post-id 123",
+    ),
     (
         inv.parse_plan,
         [],


### PR DESCRIPTION
## Summary
- allow specifying a post id in the dspy experiment
- pass optional `--post-id` through the automation CLI
- update invoke task and tests for new parameter

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68803f8510e0832ab445614ff7402982