### PR TITLE
Fix dspy_exp post-id argument handling

### DIFF
--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -100,7 +100,7 @@ def chat(
 
 
 @app.command()
-def dspy_experiment(post_id: Optional[int] = None) -> None:
+def dspy_experiment(post_id: Optional[str] = None) -> None:
     """Run the standalone dspy experiment script."""
 
     cmd = ["python", "src/experiments/dspy_exp.py"]

--- a/src/experiments/dspy_exp.py
+++ b/src/experiments/dspy_exp.py
@@ -18,7 +18,7 @@ from auto.models import Post
 from typing import Optional
 
 
-def main(post_id: Optional[int] = None) -> None:
+def main(post_id: Optional[str] = None) -> None:
     """Render the preview template and send it to a local LLM."""
     template_path = os.getenv(
         "PREVIEW_TEMPLATE_PATH",
@@ -55,6 +55,10 @@ def main(post_id: Optional[int] = None) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Summarize a Post with dspy")
-    parser.add_argument("--post-id", type=int, help="ID of the Post to summarize")
+    parser.add_argument(
+        "--post-id",
+        type=str,
+        help="ID or URL of the Post to summarize",
+    )
     args = parser.parse_args()
     main(post_id=args.post_id)

--- a/tasks.py
+++ b/tasks.py
@@ -199,7 +199,7 @@ def replay(c, name="facebook"):
     c.run(cmd, pty=True)
 
 
-@task(help={"post_id": "ID of the post to summarize"})
+@task(help={"post_id": "ID or URL of the post to summarize"})
 def dspy_exp(c, post_id):
     """Run the standalone dspy experiment."""
 

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -97,9 +97,9 @@ TEST_CASES = [
     ),
     (
         inv.dspy_exp,
-        [123],
+        ["abc"],
         {},
-        "python -m auto.cli automation dspy-experiment --post-id 123",
+        "python -m auto.cli automation dspy-experiment --post-id abc",
     ),
     (
         inv.parse_plan,


### PR DESCRIPTION
## Summary
- treat `--post-id` as a string for the dspy experiment
- update task help text for clarity
- adjust Invoke task tests for string post IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880414cd4ac832abe218e67a8c82f74