### PR TITLE
Include post_id in preview generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ python -m auto.cli publish edit-preview --post-id <id> --network mastodon
 ```
 
 `generate-preview` uses a local LLM when available and falls back to a simple template. Previews are only created when the post has been scheduled.
+The template can reference the original post URL via `{{ post_id }}`.
 
 For a step-by-step walkthrough of generating, scheduling and editing previews, see [docs/previews.md](docs/previews.md).
 

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -17,7 +17,8 @@ python -m auto.cli publish generate-preview --post-id <id> --network mastodon
 This fetches the post from the database and generates a preview. The text sent
 to the LLM is loaded from the file specified by the `PREVIEW_TEMPLATE_PATH`
 environment variable or `src/auto/templates/medium_preview_prompt.txt` by default. The
-previous preview is removed before the new one is saved. When `--use-llm` is
+template receives the post content via `{{ content }}` and the original URL as
+`{{ post_id }}`. The previous preview is removed before the new one is saved. When `--use-llm` is
 provided, a local LLM creates the summary using the same configuration as the
 `dspy-exp` experiment (`ollama_chat/gemma3:4b` on `http://localhost:11434`).
 Otherwise the post title or summary is used.

--- a/src/auto/preview.py
+++ b/src/auto/preview.py
@@ -37,7 +37,7 @@ def create_preview(
             / f"{network}_preview_prompt.txt"
         )
     template_str = Path(template_path).read_text()
-    message = Template(template_str).render(content=post.content or "")
+    message = Template(template_str).render(content=post.content or "", post_id=post_id)
 
     if use_llm:
         try:

--- a/src/auto/templates/medium_preview_prompt.txt
+++ b/src/auto/templates/medium_preview_prompt.txt
@@ -4,15 +4,17 @@ Task:
 1. Read the full article content provided below (in HTML or Markdown).
 2. Extract and rewrite:
    a. A 1-sentence hook that captures the most provocative insight.
-   b. Three concise bullet-point takeaways (2–3 lines each).
-   c. A 1-line call-to-action linking back to the Substack post.
+  b. Three concise bullet-point takeaways (2–3 lines each).
+  c. A 1-line call-to-action linking back to the Substack post at {{ post_id }}.
 3. Write in a first-person, conversational tone appropriate for Medium:
    - Keep total post length under 300 words.
    - Use Medium formatting (one blank line between sections).
    - End with an open question to spark comments.
 4. Generate meta-instructions for the editor:
-   - Set the “Originally published elsewhere” canonical URL to the original Substack link.
+  - Set the “Originally published elsewhere” canonical URL to {{ post_id }}.
    - Tag with up to five relevant hashtags (no more).
 5. Do NOT include the full article text—only the hook, bullets, CTA, and question.
+
+Original post URL: {{ post_id }}
 
 {{ content }}


### PR DESCRIPTION
## Summary
- add `post_id` variable to preview template
- document how templates use `{{ post_id }}`
- pass post_id when rendering preview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804b9bdaf0832a8a76c12841a482c8