### PR TITLE
Add delete-preview CLI task

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Previews are small templates used when posting to other networks. They can be li
 python -m auto.cli publish list-previews
 python -m auto.cli publish generate-preview --post-id <id> --network mastodon
 python -m auto.cli publish edit-preview --post-id <id> --network mastodon
+python -m auto.cli publish delete-preview --post-id <id> --network mastodon
 ```
 
 `generate-preview` uses a local LLM when available and falls back to a simple template. Previews are only created when the post has been scheduled.

--- a/docs/previews.md
+++ b/docs/previews.md
@@ -41,6 +41,14 @@ python -m auto.cli publish edit-preview --post-id <id> --network mastodon
 
 Your editor opens with the current template. Saving the file updates the `post_previews` entry for that network.
 
+## Deleting a Preview
+
+Remove an existing preview if you no longer want to keep it:
+
+```bash
+python -m auto.cli publish delete-preview --post-id <id> --network mastodon
+```
+
 ## Scheduler Pickup
 
 The background scheduler looks for due tasks in the `tasks` table. When it encounters a `create_preview` task it calls `auto.preview.create_preview` to generate the preview. When a `publish_post` task runs, the scheduler loads the corresponding preview, renders it with Jinja, and posts the result via the appropriate plugin.

--- a/src/auto/cli/publish.py
+++ b/src/auto/cli/publish.py
@@ -262,6 +262,20 @@ def edit_preview(post_id: str, network: str = "mastodon") -> None:
     print("Preview updated")
 
 
+@app.command()
+def delete_preview(post_id: str, network: str = "mastodon") -> None:
+    """Delete a stored post preview."""
+
+    with SessionLocal() as session:
+        preview = session.get(PostPreview, {"post_id": post_id, "network": network})
+        if preview is None:
+            print("Preview not found")
+            return
+        session.delete(preview)
+        session.commit()
+    print("Preview deleted")
+
+
 @app.async_command()
 async def sync_mastodon_posts() -> None:
     """Mark posts as published if they already appear on Mastodon."""

--- a/tasks.py
+++ b/tasks.py
@@ -124,6 +124,20 @@ def edit_preview(c, post_id, network="mastodon"):
 
 @task(
     help={
+        "post_id": "ID of the post to delete",
+        "network": "Target social network (default: mastodon)",
+    }
+)
+def delete_preview(c, post_id, network="mastodon"):
+    """Remove a stored preview."""
+    c.run(
+        f"python -m auto.cli publish delete-preview {post_id} --network {network}",
+        pty=True,
+    )
+
+
+@task(
+    help={
         "limit": "Number of tags to display",
         "instance": "Mastodon instance URL",
         "token": "Access token for the instance",

--- a/tests/test_delete_preview_cli.py
+++ b/tests/test_delete_preview_cli.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timezone
+
+from auto.cli import publish as tasks
+from auto.db import SessionLocal
+from auto.models import Post, PostStatus, PostPreview
+
+
+def test_delete_preview_removes_entry(test_db_engine):
+    with SessionLocal() as session:
+        post = Post(id="1", title="T", link="http://ex", summary="", published="")
+        status = PostStatus(
+            post_id="1", network="mastodon", scheduled_at=datetime.now(timezone.utc)
+        )
+        preview = PostPreview(post_id="1", network="mastodon", content="text")
+        session.add_all([post, status, preview])
+        session.commit()
+
+    tasks.delete_preview(post_id="1", network="mastodon")
+
+    with SessionLocal() as session:
+        result = session.get(PostPreview, {"post_id": "1", "network": "mastodon"})
+        assert result is None

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -58,6 +58,12 @@ TEST_CASES = [
         "python -m auto.cli publish edit-preview 123 --network twitter",
     ),
     (
+        inv.delete_preview,
+        ["abc"],
+        {"network": "mastodon"},
+        "python -m auto.cli publish delete-preview abc --network mastodon",
+    ),
+    (
         inv.trending_tags,
         [],
         {"limit": 3, "instance": "mastodon.social", "token": "tok"},


### PR DESCRIPTION
## Summary
- add `delete_preview` function to invoke tasks
- support deleting previews via CLI
- document the new command
- test the CLI and task helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688053346adc832a9bc7d959a36ca19f