### PR TITLE
Expose use_llm in create-preview task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -98,14 +98,15 @@ def generate_preview(c, post_id, network="mastodon"):
     help={
         "post_id": "ID of the post to generate a preview for",
         "network": "Target social network (default: mastodon)",
+        "use_llm": "Generate the preview using the LLM",
     }
 )
-def create_preview(c, post_id, network="mastodon"):
+def create_preview(c, post_id, network="mastodon", use_llm=False):
     """Generate a preview template via the LLM."""
-    c.run(
-        f"python -m auto.cli publish create-preview {post_id} --network {network}",
-        pty=True,
-    )
+    cmd = f"python -m auto.cli publish create-preview {post_id} --network {network}"
+    if use_llm:
+        cmd += " --use-llm"
+    c.run(cmd, pty=True)
 
 
 @task(

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -52,6 +52,12 @@ TEST_CASES = [
         "python -m auto.cli publish create-preview 123 --network mastodon",
     ),
     (
+        inv.create_preview,
+        [123],
+        {"use_llm": True},
+        "python -m auto.cli publish create-preview 123 --network mastodon --use-llm",
+    ),
+    (
         inv.edit_preview,
         [123],
         {"network": "twitter"},


### PR DESCRIPTION
## Summary
- add a `use_llm` option to the `create_preview` invoke task
- test passing the flag through to the CLI
- refine command construction to avoid spacing issues

## Testing
- `ruff check tasks.py tests/test_invoke_tasks.py`
- `black --check tasks.py tests/test_invoke_tasks.py`
- `pytest tests/test_invoke_tasks.py::test_invoke_tasks -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880f9df4568832a8b84524226b2ab95