### PR TITLE
Avoid LLM in preview test

### DIFF
--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -22,12 +22,16 @@ def test_create_preview_replaces(session, tmp_path):
     template = tmp_path / "tmpl.txt"
     template.write_text("Summary:\n{{ content }}")
 
-    create_preview(session, "p1", "mastodon", template_path=str(template))
+    create_preview(
+        session, "p1", "mastodon", template_path=str(template), use_llm=False
+    )
 
     first = session.get(PostPreview, {"post_id": "p1", "network": "mastodon"})
     assert first is not None
     template.write_text("Updated:\n{{ content }}")
-    create_preview(session, "p1", "mastodon", template_path=str(template))
+    create_preview(
+        session, "p1", "mastodon", template_path=str(template), use_llm=False
+    )
 
     second = session.get(PostPreview, {"post_id": "p1", "network": "mastodon"})
     assert second is not None


### PR DESCRIPTION
## Summary
- skip the LLM call in `test_create_preview_replaces`

## Testing
- `pre-commit run --files tests/test_preview.py`
- `pytest tests/test_preview.py::test_create_preview_replaces -q`

------
https://chatgpt.com/codex/tasks/task_e_688102b0a208832aa3d15868e8d82064