### PR TITLE
Fix httpx deprecation warnings in tests

### DIFF
--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -22,12 +22,12 @@ def test_create_preview_replaces(session, tmp_path):
     template = tmp_path / "tmpl.txt"
     template.write_text("Summary:\n{{ content }}")
 
-    create_preview(session, "p1", "mastodon", template_path=str(template))
+    create_preview(session, "p1", "mastodon", template_path=str(template), use_llm=False)
 
     first = session.get(PostPreview, {"post_id": "p1", "network": "mastodon"})
     assert first is not None
     template.write_text("Updated:\n{{ content }}")
-    create_preview(session, "p1", "mastodon", template_path=str(template))
+    create_preview(session, "p1", "mastodon", template_path=str(template), use_llm=False)
 
     second = session.get(PostPreview, {"post_id": "p1", "network": "mastodon"})
     assert second is not None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -198,7 +198,14 @@ def test_publish_failure_metrics(test_db_engine, monkeypatch):
     assert POSTS_FAILED.labels(network="mastodon")._value.get() == start + 1
 
 
-def test_create_preview_task(test_db_engine):
+def test_create_preview_task(test_db_engine, monkeypatch):
+    from auto import preview as preview_module
+    monkeypatch.setattr(
+        "auto.scheduler._create_preview",
+        lambda session, post_id, network: preview_module.create_preview(
+            session, post_id, network, use_llm=False
+        ),
+    )
     with SessionLocal() as session:
         post = Post(
             id="3", title="T3", link="http://example3", summary="", published=""


### PR DESCRIPTION
## Summary
- avoid invoking the LLM during preview tests
- prevent scheduler preview tasks from calling the LLM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688102bc4a10832a8faf949c94d31146