### PR TITLE
Extend Safari control variables

### DIFF
--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -433,7 +433,9 @@ def _interactive_menu(
 
 
 @app.command()
-def control_safari() -> None:
+def control_safari(
+    post_id: Optional[str] = None, network: str = "mastodon"
+) -> None:
     """Interactively control Safari via a menu loop."""
 
     test_name = input("Test name: ")
@@ -446,6 +448,10 @@ def control_safari() -> None:
     controller = SafariController()
     collected: list[list[str]] = []
     variables: dict[str, str] = {}
+    if post_id is not None:
+        variables["post_id"] = post_id
+    if network:
+        variables["network"] = network
     collected, _, aborted = _interactive_menu(
         controller, test_dir, collected, 1, variables
     )

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -250,3 +250,28 @@ def test_control_safari_abort(monkeypatch):
 
     test_dir = Path("tests/fixtures/demo_abort")
     assert not test_dir.exists()
+
+
+def test_control_safari_initial_vars(monkeypatch):
+    controller = DummyController()
+    monkeypatch.setattr(tasks, "SafariController", lambda: controller)
+
+    recorded = {}
+
+    def fake_menu(controller, test_dir, collected, step, variables):
+        recorded.update(variables)
+        return collected, step, True
+
+    monkeypatch.setattr(tasks, "_interactive_menu", fake_menu)
+
+    text_inputs = iter([
+        "demo_vars",
+    ])
+    monkeypatch.setattr("builtins.input", lambda _: next(text_inputs))
+
+    tasks.control_safari(post_id="42", network="testnet")
+
+    assert recorded["post_id"] == "42"
+    assert recorded["network"] == "testnet"
+    test_dir = Path("tests/fixtures/demo_vars")
+    assert not test_dir.exists()


### PR DESCRIPTION
## Summary
- allow `control_safari` to accept optional `post_id` and `network`
- forward those values to the interactive menu
- test passing variables via CLI

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881053a84dc832aa7794eaf53507d27