### PR TITLE
Add load_post to Safari menu

### DIFF
--- a/tests/test_replay_continue.py
+++ b/tests/test_replay_continue.py
@@ -41,7 +41,7 @@ def test_replay_continue(monkeypatch, tmp_path):
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
     monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
 
-    key_inputs = iter(["6", "a"])  # fetch_dom then quit
+    key_inputs = iter(["6", "b"])  # fetch_dom then quit
     monkeypatch.setattr(tasks, "_read_key", lambda: next(key_inputs))
     inputs = iter(["y"])  # continue recording
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))


### PR DESCRIPTION
## Summary
- extend `_interactive_menu` with a `load_post` command
- update command indices in Safari tests
- test `load_post` behavior

## Testing
- `black --check src/auto/cli/automation.py tests/test_control_safari.py tests/test_replay_continue.py`
- `ruff check src/auto/cli/automation.py tests/test_control_safari.py tests/test_replay_continue.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881077bd768832aa6d16b056655c516