### PR TITLE
Register Twitter client

### DIFF
--- a/src/auto/main.py
+++ b/src/auto/main.py
@@ -10,6 +10,7 @@ from .web_posts import router as posts_router
 from .socials.registry import get_registry
 from .socials.mastodon_client import MastodonClient
 from .socials.medium_client import MediumClient
+from .socials.twitter_client import TwitterClient
 import logging
 
 logger = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ async def lifespan(app: FastAPI):
     reg = get_registry()
     reg.register(MastodonClient())
     reg.register(MediumClient())
+    reg.register(TwitterClient())
     sched = Scheduler()
     await sched.start()
     try:

--- a/src/auto/socials/twitter_client.py
+++ b/src/auto/socials/twitter_client.py
@@ -1,0 +1,21 @@
+import logging
+from typing import Dict
+
+from .base import SocialPlugin
+
+logger = logging.getLogger(__name__)
+
+
+class TwitterClient(SocialPlugin):
+    """Minimal Twitter plugin placeholder."""
+
+    network = "twitter"
+
+    async def post(self, text: str, visibility: str = "public") -> None:
+        """Pretend to publish ``text`` to Twitter."""
+        logger.info("Posting to Twitter: %s", text)
+
+    async def fetch_metrics(self, post_id: str) -> Dict[str, int]:
+        """Return dummy engagement metrics for ``post_id``."""
+        logger.info("Fetching metrics for tweet %s", post_id)
+        return {}


### PR DESCRIPTION
## Summary
- add minimal TwitterClient implementation
- import TwitterClient and register it with the plugin registry

## Testing
- `ruff check src/auto/main.py src/auto/socials/twitter_client.py`
- `black --check src/auto/main.py src/auto/socials/twitter_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810adc5440832aab95698cb11c0f28