### PR TITLE
Add tweet text fill step

### DIFF
--- a/tests/fixtures/twitter/commands.json
+++ b/tests/fixtures/twitter/commands.json
@@ -40,6 +40,11 @@
     "tests/site_js/facebook.js"
   ],
   [
+    "fill",
+    "div[aria-label='Tweet text']",
+    "{{ tweet }}"
+  ],
+  [
     "close_tab"
   ]
 ]


### PR DESCRIPTION
## Summary
- update twitter fixture to fill tweet text before closing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68810ac60a84832a9aad9ab828c2fe7e