### PR TITLE
Improve post form test speed

### DIFF
--- a/tests/test_post_form.py
+++ b/tests/test_post_form.py
@@ -1,12 +1,15 @@
-import auto.main as main
 from auto.db import SessionLocal
 from auto.models import Post
 from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from auto.web_posts import router as posts_router
 
 
 def test_post_form_insert(test_db_engine, monkeypatch):
     monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
-    with TestClient(main.app) as client:
+    app = FastAPI()
+    app.include_router(posts_router)
+    with TestClient(app) as client:
         resp = client.get("/posts/new")
         assert resp.status_code == 200
         assert "<form" in resp.text


### PR DESCRIPTION
## Summary
- avoid heavy `main.app` in post form test
- build a lightweight FastAPI app using just the posts router

## Testing
- `pytest tests/test_post_form.py::test_post_form_insert -vv`


------
https://chatgpt.com/codex/tasks/task_e_68810e5c5b1c832aad583d7e9d954487