### PR TITLE
Fix slow replay_continue test

### DIFF
--- a/tests/test_replay_continue.py
+++ b/tests/test_replay_continue.py
@@ -63,6 +63,7 @@ def test_replay_initial_vars(monkeypatch, tmp_path):
     controller = DummyController()
     monkeypatch.setattr(tasks, "SafariController", lambda: controller)
     monkeypatch.setattr(tasks, "fetch_dom_html", lambda url=None: "<html></html>")
+    monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
 
     recorded = {}
 


### PR DESCRIPTION
## Summary
- skip the slow-printed output in `test_replay_initial_vars`

## Testing
- `pytest -k test_replay_continue -vv`

------
https://chatgpt.com/codex/tasks/task_e_68812740d420832a804d5a72fc9d7f82