### PR TITLE
Fix undefined logger in Twitter client

### DIFF
--- a/src/auto/socials/twitter_client.py
+++ b/src/auto/socials/twitter_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import Dict
 
 from jinja2 import Template
@@ -9,6 +10,8 @@ from jinja2 import Template
 from ..automation.safari import SafariController
 from ..utils import project_root
 from .base import SocialPlugin
+
+logger = logging.getLogger(__name__)
 
 
 class TwitterClient(SocialPlugin):


### PR DESCRIPTION
## Summary
- import `logging` in `twitter_client`
- define a module-level logger

## Testing
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688132e7b080832a98f77595192511a1