### PR TITLE
Add mark_published task and spec

### DIFF
--- a/spec/mark_published.md
+++ b/spec/mark_published.md
@@ -1,0 +1,15 @@
+# Mark Published
+Record that a post was successfully published on a network.
+
+```json
+{
+  "title": "mark_published",
+  "description": "Record that a post has been published on a network",
+  "type": "object",
+  "properties": {
+    "network": {"type": "string", "description": "Social network name"},
+    "post_id": {"type": "string", "description": "ID of the post"}
+  },
+  "required": ["network", "post_id"]
+}
+```

--- a/src/auto/mark_published.py
+++ b/src/auto/mark_published.py
@@ -1,0 +1,30 @@
+"""Task handler for marking a post as published."""
+
+from __future__ import annotations
+
+import json
+import logging
+from sqlalchemy.orm import Session
+
+from .scheduler import register_task_handler
+from .models import PostStatus, Task
+
+logger = logging.getLogger(__name__)
+
+
+@register_task_handler("mark_published")
+async def handle_mark_published(task: Task, session: Session) -> None:
+    """Mark ``post_id`` as published on ``network``."""
+    data = json.loads(task.payload or "{}")
+    post_id = data.get("post_id")
+    network = data.get("network")
+    if not post_id or not network:
+        raise ValueError("post_id and network are required")
+
+    status = session.get(PostStatus, {"post_id": post_id, "network": network})
+    if status is None:
+        status = PostStatus(post_id=post_id, network=network, status="published")
+        session.add(status)
+    else:
+        status.status = "published"
+    session.commit()

--- a/tests/test_mark_published.py
+++ b/tests/test_mark_published.py
@@ -1,0 +1,44 @@
+import asyncio
+import json
+
+from auto.db import SessionLocal
+from auto.models import PostStatus, Task
+from auto.mark_published import handle_mark_published
+
+
+async def run(task, session):
+    await handle_mark_published(task, session)
+
+
+def test_mark_published_creates_status(test_db_engine):
+    with SessionLocal() as session:
+        task = Task(
+            type="mark_published",
+            payload=json.dumps({"post_id": "1", "network": "mastodon"}),
+        )
+        session.add(task)
+        session.commit()
+
+        asyncio.run(run(task, session))
+
+        status = session.get(PostStatus, {"post_id": "1", "network": "mastodon"})
+        assert status is not None
+        assert status.status == "published"
+
+
+def test_mark_published_updates_existing(test_db_engine):
+    with SessionLocal() as session:
+        session.add(
+            PostStatus(post_id="1", network="mastodon", status="pending")
+        )
+        task = Task(
+            type="mark_published",
+            payload=json.dumps({"post_id": "1", "network": "mastodon"}),
+        )
+        session.add(task)
+        session.commit()
+
+        asyncio.run(run(task, session))
+
+        status = session.get(PostStatus, {"post_id": "1", "network": "mastodon"})
+        assert status.status == "published"


### PR DESCRIPTION
## Summary
- implement `mark_published` task handler
- provide spec file for `mark_published`
- add tests verifying the task

## Testing
- `pytest -k mark_published -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881321481c8832a80aaabe5019999b5