### PR TITLE
Configure Black to ignore fixture data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ dependencies = [
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+extend-exclude = "tests/fixtures"

--- a/tests/test_mark_published.py
+++ b/tests/test_mark_published.py
@@ -28,9 +28,7 @@ def test_mark_published_creates_status(test_db_engine):
 
 def test_mark_published_updates_existing(test_db_engine):
     with SessionLocal() as session:
-        session.add(
-            PostStatus(post_id="1", network="mastodon", status="pending")
-        )
+        session.add(PostStatus(post_id="1", network="mastodon", status="pending"))
         task = Task(
             type="mark_published",
             payload=json.dumps({"post_id": "1", "network": "mastodon"}),

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -22,12 +22,16 @@ def test_create_preview_replaces(session, tmp_path):
     template = tmp_path / "tmpl.txt"
     template.write_text("Summary:\n{{ content }}")
 
-    create_preview(session, "p1", "mastodon", template_path=str(template), use_llm=False)
+    create_preview(
+        session, "p1", "mastodon", template_path=str(template), use_llm=False
+    )
 
     first = session.get(PostPreview, {"post_id": "p1", "network": "mastodon"})
     assert first is not None
     template.write_text("Updated:\n{{ content }}")
-    create_preview(session, "p1", "mastodon", template_path=str(template), use_llm=False)
+    create_preview(
+        session, "p1", "mastodon", template_path=str(template), use_llm=False
+    )
 
     second = session.get(PostPreview, {"post_id": "p1", "network": "mastodon"})
     assert second is not None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -200,6 +200,7 @@ def test_publish_failure_metrics(test_db_engine, monkeypatch):
 
 def test_create_preview_task(test_db_engine, monkeypatch):
     from auto import preview as preview_module
+
     monkeypatch.setattr(
         "auto.scheduler._create_preview",
         lambda session, post_id, network: preview_module.create_preview(


### PR DESCRIPTION
## Summary
- configure Black to skip the `tests/fixtures` path
- format tests to satisfy Black after config change

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688251a4c848832ab8a96c5401a00f00