### PR TITLE
Improve load_post to parse JSON previews

### DIFF
--- a/spec/preview_variables.md
+++ b/spec/preview_variables.md
@@ -1,0 +1,15 @@
+# Preview Variables
+Describe template variables loaded from post previews.
+
+```json
+{
+  "title": "preview_variables",
+  "description": "Variables extracted from PostPreview.content",
+  "type": "object",
+  "properties": {
+    "tweet": {"type": "string", "description": "Main tweet text"},
+    "img_url": {"type": "string", "description": "Optional image URL"},
+    "tags": {"type": "string", "description": "Optional tag list"}
+  }
+}
+```

--- a/src/auto/cli/automation.py
+++ b/src/auto/cli/automation.py
@@ -443,8 +443,20 @@ def _interactive_menu(
                 post = session.get(Post, post_id)
 
             if preview and post:
-                variables["tweet"] = Template(preview.content).render(post=post)
-                print("Preview loaded into variables['tweet']")
+                try:
+                    data = json.loads(preview.content)
+                except Exception:
+                    data = None
+
+                if isinstance(data, dict):
+                    for key, value in data.items():
+                        if isinstance(value, str):
+                            variables[key] = Template(value).render(post=post)
+                    loaded = ", ".join(data.keys()) if data else ""
+                    print(f"Preview loaded into variables: {loaded}")
+                else:
+                    variables["tweet"] = Template(preview.content).render(post=post)
+                    print("Preview loaded into variables['tweet']")
                 collected.append(["load_post", post_id, network])
             else:
                 print("Post or preview not found")

--- a/tests/test_control_safari.py
+++ b/tests/test_control_safari.py
@@ -286,7 +286,9 @@ def test_interactive_menu_load_post(monkeypatch, test_db_engine, tmp_path):
     with SessionLocal() as session:
         post = Post(id="1", title="T", link="http://ex", summary="", published="")
         preview = PostPreview(
-            post_id="1", network="mastodon", content="Hello {{post.title}}"
+            post_id="1",
+            network="mastodon",
+            content='{"tweet": "Hello {{post.title}}"}',
         )
         session.add_all([post, preview])
         session.commit()


### PR DESCRIPTION
## Summary
- allow interactive Safari menu to parse JSON previews
- update tests for new JSON structure
- document preview variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826151848c832a95a766fe977a565f