### PR TITLE
Enable load_post during replay

### DIFF
--- a/spec/load_post.md
+++ b/spec/load_post.md
@@ -1,0 +1,15 @@
+# Load Post
+Load preview content into variables for replay.
+
+```json
+{
+  "title": "load_post",
+  "description": "Load a post preview and store template variables",
+  "type": "object",
+  "properties": {
+    "post_id": {"type": "string", "description": "ID of the post"},
+    "network": {"type": "string", "description": "Target social network"}
+  },
+  "required": ["post_id", "network"]
+}
+```

--- a/tests/fixtures/load_post/commands.json
+++ b/tests/fixtures/load_post/commands.json
@@ -1,0 +1,4 @@
+[
+  ["load_post", "{{post_id}}", "{{network}}"],
+  ["open", "{{tweet}}"]
+]

--- a/tests/test_replay_template.py
+++ b/tests/test_replay_template.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from auto.cli import automation as tasks
 
+
 class DummyController:
     def __init__(self):
         self.calls = []
@@ -27,6 +28,7 @@ class DummyController:
         self.calls.append(("close_tab",))
         return "OK"
 
+
 def test_replay_template_variable(monkeypatch, tmp_path):
     src = Path("tests/fixtures/open_var")
     dst = tmp_path / "tests" / "fixtures" / "open_var"
@@ -43,3 +45,34 @@ def test_replay_template_variable(monkeypatch, tmp_path):
     tasks.replay("open_var", post_id=url)
 
     assert ("open", url) in controller.calls
+
+
+def test_replay_load_post(monkeypatch, tmp_path, test_db_engine):
+    src = Path("tests/fixtures/load_post")
+    dst = tmp_path / "tests" / "fixtures" / "load_post"
+    shutil.copytree(src, dst)
+    monkeypatch.chdir(tmp_path)
+
+    from auto.db import SessionLocal
+    from auto.models import Post, PostPreview
+
+    with SessionLocal() as session:
+        post = Post(id="1", title="T", link="http://ex", summary="", published="")
+        preview = PostPreview(
+            post_id="1",
+            network="mastodon",
+            content='{"tweet": "Hello {{post.title}}"}',
+        )
+        session.add_all([post, preview])
+        session.commit()
+
+    controller = DummyController()
+    monkeypatch.setattr(tasks, "SafariController", lambda: controller)
+    monkeypatch.setenv("SKIP_SLOW_PRINT", "1")
+
+    inputs = iter(["n"])  # do not continue recording
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    tasks.replay("load_post", post_id="1", network="mastodon")
+
+    assert ("open", "Hello T") in controller.calls


### PR DESCRIPTION
## Summary
- support `load_post` command when replaying recorded browser actions
- document new load_post command
- add fixture and tests for replaying with a loaded post

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688265aef760832aaec2d5d7d3b5a585