### PR TITLE
Add mark_published replay command

### DIFF
--- a/spec/mark_published.md
+++ b/spec/mark_published.md
@@ -1,5 +1,7 @@
 # Mark Published
 Record that a post was successfully published on a network.
+The interactive `mark_published` command uses stored `post_id` and `network`
+variables to update both the `PostPreview` and `PostStatus` tables.
 
 ```json
 {

--- a/tests/fixtures/mark_published/commands.json
+++ b/tests/fixtures/mark_published/commands.json
@@ -1,0 +1,4 @@
+[
+  ["llm_query", "unused", "Posted text", "tweet"],
+  ["mark_published", "{{post_id}}", "{{network}}"]
+]


### PR DESCRIPTION
## Summary
- add `mark_published` command to interactive menu and replay
- allow updating preview text and status using stored variables
- document the command in `mark_published` spec
- test interactive menu and replay behaviour

## Testing
- `pre-commit run --files spec/mark_published.md src/auto/cli/automation.py tests/test_control_safari.py tests/test_replay_template.py tests/fixtures/mark_published/commands.json`

------
https://chatgpt.com/codex/tasks/task_e_68827194ac20832a89e8608207758c64