### PR TITLE
Add fixture dump/load tasks

### DIFF
--- a/spec/dump_fixtures.md
+++ b/spec/dump_fixtures.md
@@ -1,0 +1,13 @@
+# Dump Fixtures
+Create a SQL dump of the database schema and contents.
+
+```json
+{
+  "title": "dump_fixtures",
+  "description": "Dump the SQLite schema and data to a SQL file",
+  "type": "object",
+  "properties": {
+    "path": {"type": "string", "description": "Output file path"}
+  }
+}
+```

--- a/spec/load_fixtures.md
+++ b/spec/load_fixtures.md
@@ -1,0 +1,13 @@
+# Load Fixtures
+Load schema and data from a SQL dump into the database.
+
+```json
+{
+  "title": "load_fixtures",
+  "description": "Load schema and data from a SQL file into the database",
+  "type": "object",
+  "properties": {
+    "path": {"type": "string", "description": "SQL dump file to load"}
+  }
+}
+```

--- a/tasks.py
+++ b/tasks.py
@@ -195,6 +195,26 @@ def metrics(c, host="localhost", port=8000):
     )
 
 
+@task(help={"path": "Destination SQL file"})
+def dump_fixtures(c, path="tests/fixtures/db.sql"):
+    """Dump the SQLite database to ``path``."""
+
+    c.run(
+        f"python -m auto.cli maintenance dump-fixtures --path {path}",
+        pty=True,
+    )
+
+
+@task(help={"path": "SQL file to load"})
+def load_fixtures(c, path="tests/fixtures/db.sql"):
+    """Load database content from ``path``."""
+
+    c.run(
+        f"python -m auto.cli maintenance load-fixtures --path {path}",
+        pty=True,
+    )
+
+
 @task
 def safari_control(c):
     """Open the interactive Safari controller menu."""

--- a/tests/test_dump_load_fixtures.py
+++ b/tests/test_dump_load_fixtures.py
@@ -1,0 +1,20 @@
+from auto.cli import maintenance
+from auto.db import SessionLocal
+from auto.models import Post
+
+
+def test_dump_and_load_fixtures(test_db_engine, tmp_path):
+    dump_file = tmp_path / "dump.sql"
+
+    with SessionLocal() as session:
+        session.add(Post(id="1", title="T", link="http://ex"))
+        session.commit()
+
+    maintenance.dump_fixtures(path=str(dump_file))
+
+    maintenance.load_fixtures(path=str(dump_file))
+
+    with SessionLocal() as session:
+        posts = session.query(Post).all()
+        assert len(posts) == 1
+        assert posts[0].id == "1"

--- a/tests/test_invoke_tasks.py
+++ b/tests/test_invoke_tasks.py
@@ -94,6 +94,18 @@ TEST_CASES = [
         {"host": "0.0.0.0", "port": 9000},
         "python -m auto.cli maintenance metrics --host 0.0.0.0 --port 9000",
     ),
+    (
+        inv.dump_fixtures,
+        [],
+        {"path": "out.sql"},
+        "python -m auto.cli maintenance dump-fixtures --path out.sql",
+    ),
+    (
+        inv.load_fixtures,
+        [],
+        {"path": "out.sql"},
+        "python -m auto.cli maintenance load-fixtures --path out.sql",
+    ),
     (inv.safari_control, [], {}, "python -m auto.cli automation control-safari"),
     (
         inv.replay,


### PR DESCRIPTION
## Summary
- implement `dump-fixtures` and `load-fixtures` maintenance commands
- expose new `dump_fixtures` and `load_fixtures` invoke tasks
- document the commands in new specs
- test dumping and loading of fixtures
- verify invoke tasks

## Testing
- `pre-commit run --files src/auto/cli/maintenance.py tasks.py tests/test_invoke_tasks.py tests/test_dump_load_fixtures.py spec/dump_fixtures.md spec/load_fixtures.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688278f3614c832a91ef10ef77a4cbc6