### PR TITLE
Validate JSON for create_preview

### DIFF
--- a/spec/validate_preview_json.md
+++ b/spec/validate_preview_json.md
@@ -1,0 +1,10 @@
+# Validate Preview JSON
+Abort `create_preview` if the generated content is not valid JSON.
+
+```json
+{
+  "title": "validate_preview_json",
+  "description": "Ensure preview content is a JSON object when generated via the LLM",
+  "type": "object"
+}
+```

--- a/src/auto/preview.py
+++ b/src/auto/preview.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 import dspy
+import json
 from jinja2 import Template
 from sqlalchemy.orm import Session
 
@@ -51,8 +52,14 @@ def create_preview(
             if isinstance(response, list):
                 response = response[0]
             content = str(response).strip()
-        except Exception:
-            content = post.summary or post.title
+        except Exception as exc:
+            raise ValueError(f"LLM failed: {exc}") from exc
+        try:
+            parsed = json.loads(content)
+            if not isinstance(parsed, dict):
+                raise ValueError("preview JSON must be an object")
+        except Exception as exc:
+            raise ValueError(f"Invalid JSON preview: {exc}") from exc
     else:
         content = post.summary or post.title
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+import types
+import pytest
 from auto.preview import create_preview
 from auto.models import Post, PostStatus, PostPreview
 
@@ -36,3 +38,38 @@ def test_create_preview_replaces(session, tmp_path):
     second = session.get(PostPreview, {"post_id": "p1", "network": "mastodon"})
     assert second is not None
     assert session.query(PostPreview).count() == 1
+
+
+def test_create_preview_validates_json(session, tmp_path, monkeypatch):
+    post = Post(
+        id="p2",
+        title="Title",
+        link="http://example",
+        content="Content",
+        summary="",
+        published="",
+    )
+    status = PostStatus(
+        post_id="p2", network="mastodon", scheduled_at=datetime.now(timezone.utc)
+    )
+    session.add_all([post, status])
+    session.commit()
+
+    template = tmp_path / "tmpl.txt"
+    template.write_text("text")
+
+    class DummyLM:
+        def __call__(self, *args, **kwargs):
+            return ["not json"]
+
+    dummy = types.SimpleNamespace(
+        LM=lambda *a, **k: DummyLM(), configure=lambda *a, **k: None
+    )
+    monkeypatch.setattr("auto.preview.dspy", dummy)
+
+    with pytest.raises(ValueError):
+        create_preview(
+            session, "p2", "mastodon", template_path=str(template), use_llm=True
+        )
+
+    assert session.get(PostPreview, {"post_id": "p2", "network": "mastodon"}) is None


### PR DESCRIPTION
## Summary
- add new spec describing preview JSON validation
- ensure `create_preview` verifies LLM output is JSON
- test that invalid JSON aborts preview creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688291874a70832ab596715e6df08a39