### PR TITLE
Add quick start and contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+To set up the development environment:
+
+```bash
+pip install -r requirements.txt
+pre-commit install
+pytest
+```
+
+Invoke tasks provide handy wrappers around common commands. Run `invoke --list` to see them all.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@ The API itself is implemented with **FastAPI** and database migrations are
 handled via **Alembic**.  The project is intentionally tiny but demonstrates the
 basics needed for a multi‑publish workflow.
 
+## Quick Start
+
+Clone the repository and install its dependencies:
+
+```bash
+git clone <repo-url>
+cd auto
+pip install -r requirements.txt
+```
+
+Copy the provided environment template and start the server and scheduler:
+
+```bash
+cp .env.sample .env
+python -m auto.cli maintenance uv        # run the FastAPI server
+python -m auto.scheduler                 # run the background scheduler
+```
+
+For development details see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Environment variables
 
 Copy `.env.sample` to `.env` and adjust the values or export them manually.


### PR DESCRIPTION
## Summary
- document cloning, install, env setup and running services
- add contributing guide with basic setup steps

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_6883c31b5b54832ab2ece539f64e3463