### PR TITLE
Add queue_replay invoke task

### DIFF
--- a/spec/queue_replay.md
+++ b/spec/queue_replay.md
@@ -1,0 +1,16 @@
+# Queue Replay
+Queue a replay_fixture task via the CLI.
+
+```json
+{
+  "title": "queue_replay",
+  "description": "Queue a replay_fixture task through the CLI",
+  "type": "object",
+  "properties": {
+    "name": {"type": "string", "description": "Fixture name under tests/fixtures"},
+    "post_id": {"type": "string", "description": "ID of the post"},
+    "network": {"type": "string", "description": "Target social network"}
+  },
+  "required": ["name", "post_id", "network"]
+}
+```

--- a/tasks.py
+++ b/tasks.py
@@ -241,6 +241,21 @@ def replay(c, name="facebook", network="mastodon", post_id=None):
     c.run(cmd, pty=True)
 
 
+@task(
+    help={
+        "name": "Fixture name under tests/fixtures",
+        "post_id": "ID of the post to replay",
+        "network": "Target social network (default: mastodon)",
+    },
+    positional=["name", "post_id"],
+)
+def queue_replay(c, name, post_id, network="mastodon"):
+    """Queue a replay_fixture task for the scheduler."""
+
+    cmd = f"python -m auto.cli automation queue-replay {name} {post_id} --network {network}"
+    c.run(cmd, pty=True)
+
+
 @task(help={"post_id": "ID or URL of the post to summarize"})
 def dspy_exp(c, post_id):
     """Run the standalone dspy experiment."""


### PR DESCRIPTION
## Summary
- allow scheduling replay fixtures via Invoke
- document queue_replay CLI command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888d71fd1d0832a8a1228f81b4e5b8f