### PR TITLE
Fix scheduler handler registration

### DIFF
--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -30,6 +30,12 @@ logger = logging.getLogger(__name__)
 TASK_HANDLERS: Dict[str, Callable[[Task, Session], Awaitable[None]]] = {}
 
 
+def _load_default_handlers() -> None:
+    """Import modules that register built-in task handlers."""
+    # Imported for side effects of register_task_handler
+    from . import ingest_scheduler, replay_fixture  # noqa: F401
+
+
 def register_task_handler(
     name: str,
 ) -> Callable[
@@ -101,6 +107,7 @@ async def handle_create_preview(task: Task, session: Session) -> None:
 
 async def process_pending(max_attempts: Optional[int] = None) -> None:
     """Fetch due tasks and dispatch them to registered handlers."""
+    _load_default_handlers()
     now = datetime.now(timezone.utc)
     if max_attempts is None:
         max_attempts = get_max_attempts()


### PR DESCRIPTION
## Summary
- ensure built-in task handlers are loaded when `process_pending` runs

## Testing
- `pytest -q`
- `pytest tests/test_scheduler.py::test_replay_fixture_task -q`

------
https://chatgpt.com/codex/tasks/task_e_688926cd6860832a903a70438ee59e8a