### PR TITLE
Implement publish_completed_replays task

### DIFF
--- a/spec/publish_completed_replays_task.md
+++ b/spec/publish_completed_replays_task.md
@@ -1,0 +1,10 @@
+# Publish Completed Replays Task
+Update post status after automation replays finish.
+
+```json
+{
+  "title": "publish_completed_replays",
+  "description": "Mark posts as published when replay_fixture tasks complete",
+  "type": "object"
+}
+```

--- a/src/auto/config.py
+++ b/src/auto/config.py
@@ -50,6 +50,12 @@ def get_ingest_interval() -> int:
     return int(os.getenv("INGEST_INTERVAL", "600"))
 
 
+def get_replay_check_interval() -> int:
+    """Return the delay in seconds between replay status scans."""
+    load_env()
+    return int(os.getenv("REPLAY_CHECK_INTERVAL", "3600"))
+
+
 def get_post_delay() -> float:
     load_env()
     return float(os.getenv("POST_DELAY", "1"))

--- a/src/auto/replay_scanner.py
+++ b/src/auto/replay_scanner.py
@@ -1,0 +1,51 @@
+"""Task handler for publishing posts after successful replays."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, timedelta
+from sqlalchemy.orm import Session
+
+from .scheduler import register_task_handler
+from .models import Task, PostStatus
+from .config import get_replay_check_interval
+
+
+@register_task_handler("publish_completed_replays")
+async def handle_publish_completed_replays(task: Task, session: Session) -> None:
+    """Mark posts as published when their replay_fixture task completed."""
+    completed = (
+        session.query(Task)
+        .filter(
+            Task.type == "replay_fixture",
+            Task.status == "completed",
+        )
+        .all()
+    )
+
+    for replay_task in completed:
+        data = json.loads(replay_task.payload or "{}")
+        post_id = data.get("post_id")
+        network = data.get("network")
+        if not post_id or not network:
+            continue
+        status = session.get(PostStatus, {"post_id": post_id, "network": network})
+        if status is None:
+            status = PostStatus(post_id=post_id, network=network, status="published")
+            session.add(status)
+        else:
+            status.status = "published"
+    session.commit()
+
+    next_run = datetime.now(timezone.utc) + timedelta(seconds=get_replay_check_interval())
+    session.add(Task(type="publish_completed_replays", scheduled_at=next_run))
+    session.commit()
+
+
+
+def ensure_initial_task(session: Session) -> None:
+    """Ensure at least one publish_completed_replays task exists."""
+    exists = session.query(Task).filter(Task.type == "publish_completed_replays").first()
+    if not exists:
+        session.add(Task(type="publish_completed_replays"))
+

--- a/src/auto/scheduler.py
+++ b/src/auto/scheduler.py
@@ -33,7 +33,7 @@ TASK_HANDLERS: Dict[str, Callable[[Task, Session], Awaitable[None]]] = {}
 def _load_default_handlers() -> None:
     """Import modules that register built-in task handlers."""
     # Imported for side effects of register_task_handler
-    from . import ingest_scheduler, replay_fixture  # noqa: F401
+    from . import ingest_scheduler, replay_fixture, replay_scanner  # noqa: F401
 
 
 def register_task_handler(
@@ -189,10 +189,11 @@ class Scheduler:
                 return None
 
             # ensure ingest handler and other task handlers are registered
-            from . import ingest_scheduler, replay_fixture  # noqa: F401
+            from . import ingest_scheduler, replay_fixture, replay_scanner  # noqa: F401
 
             with SessionLocal() as session:
                 ingest_scheduler.ensure_initial_task(session)
+                replay_scanner.ensure_initial_task(session)
                 session.commit()
 
             await self._worker.start()

--- a/tests/test_replay_scanner.py
+++ b/tests/test_replay_scanner.py
@@ -1,0 +1,52 @@
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+
+from auto.db import SessionLocal
+from auto.models import Task, PostStatus
+from auto.replay_scanner import handle_publish_completed_replays
+
+
+async def run(task, session):
+    await handle_publish_completed_replays(task, session)
+
+
+def test_publish_completed_replays_task(test_db_engine, monkeypatch):
+    monkeypatch.setenv("REPLAY_CHECK_INTERVAL", "0")
+    with SessionLocal() as session:
+        # completed replay task
+        session.add(
+            Task(
+                type="replay_fixture",
+                status="completed",
+                payload=json.dumps({"post_id": "1", "network": "mastodon"}),
+            )
+        )
+        # task to trigger scanner
+        task = Task(
+            type="publish_completed_replays",
+            scheduled_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+        session.add(task)
+        session.commit()
+        task_id = task.id
+
+    with SessionLocal() as session:
+        db_task = session.get(Task, task_id)
+        assert db_task is not None
+        asyncio.run(run(db_task, session))
+
+        status = session.get(PostStatus, {"post_id": "1", "network": "mastodon"})
+        assert status is not None
+        assert status.status == "published"
+        # new task scheduled
+        next_task = (
+            session.query(Task)
+            .filter(Task.type == "publish_completed_replays")
+            .order_by(Task.id.desc())
+            .first()
+        )
+        assert next_task is not None
+        assert next_task.id != task_id
+
+


### PR DESCRIPTION
## Summary
- create `publish_completed_replays` periodic task and handler
- register handler with scheduler and ensure initial task
- add configurable interval for replay scan
- test the new task
- document task in spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889316bb844832a93e6c6a828c6e719