### PR TITLE
Add publish task when scheduling posts

### DIFF
--- a/src/auto/cli/publish.py
+++ b/src/auto/cli/publish.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 from datetime import timezone
+import json
 
 import typer
 from sqlalchemy import select, case
@@ -102,6 +103,14 @@ def schedule(post_id: str, time: str, network: Optional[str] = None) -> None:
             else:
                 ps.scheduled_at = scheduled_at
                 ps.status = "pending"
+
+            payload = json.dumps({"post_id": post_id, "network": net})
+            task = Task(
+                type="publish_post",
+                payload=payload,
+                scheduled_at=scheduled_at,
+            )
+            session.add(task)
             session.commit()
     print(
         f"Scheduled {post_id} for {', '.join(networks)} at {scheduled_at.isoformat()}"


### PR DESCRIPTION
## Summary
- queue a `publish_post` task when scheduling a post
- test that scheduling creates a corresponding task

## Testing
- `ruff check src/auto/cli/publish.py tests/test_schedule.py`
- `black --check src/auto/cli/publish.py tests/test_schedule.py`
- `pytest -q tests/test_schedule.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a4e4dd298832a91ab864c71fb7cd7