### PR TITLE
Document review follow-ups in TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,11 @@
 
 ## High Priority
 
+- Ensure Alembic migrations use the configured `DATABASE_URL` by wiring the active SQLAlchemy engine into `init_db()`.
+
 ## Medium Priority
+
+- Support reloading `.env` configuration at runtime so long-lived processes pick up changes without restarts.
 
 ## Low Priority
 - Expand social network support beyond Mastodon.
@@ -24,8 +28,11 @@
 
 ## BUGS
 
+- Degrade gracefully when Safari automation or `osascript` is unavailable so the API can start on non-macOS deployments.
+
 ## RECS
 - Add a CLI wrapper for common tasks like listing posts or scheduling to reduce reliance on Invoke.
 - Package the project so tests no longer modify `sys.path` directly.
 - Provide invoke tasks `install_hooks`, `parse_plan`, and `setup` for routine development.
 - Centralize configuration with a `Settings` class that loads environment variables at runtime.
+- Replace the implicit singleton in `get_registry()` with registry state stored on the application instance to avoid hidden globals.


### PR DESCRIPTION
## Summary
- record the need for Alembic migrations to use the configured database URL
- capture runtime `.env` reload support as a medium-priority task
- document Safari automation resilience and registry state clean-up follow-ups in TODO

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad8cb3688832a8d74154bae4ab24d